### PR TITLE
Add a release script that can't ship a broken build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ xcuserdata/
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint
+
+## Release artifacts (built by scripts/release.sh)
+TranslateMenu-*.zip

--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ You can open the application from your menubar, as well as from the macOS contex
 ## Download
 
 Get the latest binary from [the releases section](https://github.com/zetxek/osx-menubar-translate/releases).
-Unzip the file and drag & drop it into the Applications folder. Ready!
+Unzip the file and drag & drop it into the Applications folder.
 
-Requirements: macOS 12.4+.
+**The first time you open it, right-click the app and choose Open** (rather than double-clicking), then confirm. macOS will otherwise refuse to launch it, saying it can't verify the developer.
+
+That's because the app isn't notarized — notarization requires a paid Apple Developer Program membership, and this is a free app I maintain in my spare time. The build is ad-hoc signed instead, exactly as previous releases have been. You only need the right-click once; afterwards it opens normally.
+
+Requirements: macOS 12.4+, Intel or Apple Silicon.
 
 ## Features
 
@@ -80,25 +84,24 @@ xcodebuild -project "Translate Menu.xcodeproj" -scheme "Translate Menu" \
 
 ### Cutting a release (maintainers)
 
-`scripts/release.sh <version>` builds, notarizes, staples and packages a release, refusing to continue if anything is wrong. It needs two one-time setup steps:
-
-1. A **Developer ID Application** certificate in your login keychain (create at developer.apple.com → Certificates → + → Developer ID Application, then download and open it). This is what lets the app run on other people's Macs without a Gatekeeper warning — an App Store distribution certificate won't do.
-2. A notarytool keychain profile named `notary`:
-
-   ```bash
-   xcrun notarytool store-credentials notary \
-     --apple-id <your-apple-id> --team-id <your-team-id> \
-     --password <app-specific-password>
-   ```
-
-   Generate the app-specific password at appleid.apple.com → Sign-In and Security → App-Specific Passwords. It is not your Apple ID password.
-
-Then bump `MARKETING_VERSION` in both build configurations and run:
+`scripts/release.sh <version>` builds, packages and verifies a release, refusing to continue if anything is wrong. Bump `MARKETING_VERSION` in both build configurations first.
 
 ```bash
-scripts/release.sh 1.2.3
+scripts/release.sh 1.2.3 --adhoc
 gh release create v1.2.3 ./TranslateMenu-1.2.3.zip --title "v1.2.3" --notes-file notes.md
 ```
+
+`--adhoc` is currently required, because notarization needs an active Apple Developer Program membership and this project's has expired. An expired membership silently drops you to a free "Personal Team", which cannot create a Developer ID certificate or notarize at all — Xcode will only offer you Apple Development certificates.
+
+If the membership is ever renewed, drop `--adhoc` and the script will sign with Developer ID, notarize, staple and verify Gatekeeper accepts the result. That also needs a notarytool keychain profile named `notary`:
+
+```bash
+xcrun notarytool store-credentials notary \
+  --apple-id <your-apple-id> --team-id <your-team-id> \
+  --password <app-specific-password>
+```
+
+The app-specific password comes from appleid.apple.com → Sign-In and Security → App-Specific Passwords. It is not your Apple ID password.
 
 The script's flags matter. `-destination 'generic/platform=macOS'` is what produces a universal binary — without it `xcodebuild` builds only the host architecture, which is how v1.2.1 shipped arm64-only. `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO` strips the `get-task-allow` debug entitlement, which notarization rejects. The script verifies both before submitting.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,30 @@ xcodebuild -project "Translate Menu.xcodeproj" -scheme "Translate Menu" \
   DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
 ```
 
+### Cutting a release (maintainers)
+
+`scripts/release.sh <version>` builds, notarizes, staples and packages a release, refusing to continue if anything is wrong. It needs two one-time setup steps:
+
+1. A **Developer ID Application** certificate in your login keychain (create at developer.apple.com → Certificates → + → Developer ID Application, then download and open it). This is what lets the app run on other people's Macs without a Gatekeeper warning — an App Store distribution certificate won't do.
+2. A notarytool keychain profile named `notary`:
+
+   ```bash
+   xcrun notarytool store-credentials notary \
+     --apple-id <your-apple-id> --team-id <your-team-id> \
+     --password <app-specific-password>
+   ```
+
+   Generate the app-specific password at appleid.apple.com → Sign-In and Security → App-Specific Passwords. It is not your Apple ID password.
+
+Then bump `MARKETING_VERSION` in both build configurations and run:
+
+```bash
+scripts/release.sh 1.2.3
+gh release create v1.2.3 ./TranslateMenu-1.2.3.zip --title "v1.2.3" --notes-file notes.md
+```
+
+The script's flags matter. `-destination 'generic/platform=macOS'` is what produces a universal binary — without it `xcodebuild` builds only the host architecture, which is how v1.2.1 shipped arm64-only. `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO` strips the `get-task-allow` debug entitlement, which notarization rejects. The script verifies both before submitting.
+
 ## Fixes in this release
 
 - Fixed pasting text containing quotes, backslashes or newlines (hand-rolled JS escaping replaced with JSON encoding)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,20 +2,33 @@
 #
 # Build, notarize, staple and package a release build of Translate Menu.
 #
-# Usage:  scripts/release.sh 1.2.3
+# Usage:  scripts/release.sh 1.2.3            # signed + notarized (needs paid membership)
+#         scripts/release.sh 1.2.3 --adhoc    # ad-hoc signed, NOT notarized
 #
-# Prerequisites (one-time, see README "Cutting a release"):
+# Prerequisites for the default (notarized) path — see README "Cutting a release":
+#   - An active Apple Developer Program membership
 #   - A "Developer ID Application" certificate in the login keychain
 #   - A notarytool keychain profile named "notary":
 #       xcrun notarytool store-credentials notary --apple-id <you> --team-id <TEAM> --password <app-specific-password>
+#
+# --adhoc exists because the membership lapsed and notarization became
+# impossible without it. An ad-hoc build is a real trade-off: Gatekeeper
+# rejects it, so users must right-click -> Open the first time. It is how
+# v1.2.1 and earlier shipped. Prefer the notarized path whenever the
+# membership is active.
 #
 # Every flag below is load-bearing. See the comments before removing any.
 
 set -euo pipefail
 
 VERSION="${1:-}"
+ADHOC=no
+if [[ "${2:-}" == "--adhoc" ]]; then
+    ADHOC=yes
+fi
+
 if [[ -z "$VERSION" ]]; then
-    echo "usage: $0 <version>   (e.g. $0 1.2.3)" >&2
+    echo "usage: $0 <version> [--adhoc]   (e.g. $0 1.2.3)" >&2
     exit 2
 fi
 
@@ -40,16 +53,32 @@ if [[ "$PROJECT_VERSION" != "$VERSION" ]]; then
     exit 1
 fi
 
-echo "==> Checking for a Developer ID Application certificate"
-if ! security find-identity -v -p codesigning | grep -q "Developer ID Application"; then
-    echo "error: no 'Developer ID Application' certificate found in the keychain." >&2
-    echo "       Without it the app is only ad-hoc signed and Gatekeeper will reject it" >&2
-    echo "       on other people's Macs. Create one at developer.apple.com under" >&2
-    echo "       Certificates > + > Developer ID Application, then download and open it." >&2
-    exit 1
+if [[ "$ADHOC" == yes ]]; then
+    SIGN_IDENTITY="-"
+    # Hardened runtime is only meaningful alongside notarization, and enabling it
+    # on an ad-hoc build buys nothing while risking launch failures.
+    HARDENED=NO
+    echo "==> Ad-hoc mode: the app will NOT be notarized."
+    echo "    Gatekeeper will reject it and users must right-click -> Open the first"
+    echo "    time. This matches how v1.2.1 shipped. Re-run without --adhoc once the"
+    echo "    Apple Developer Program membership is active."
+else
+    SIGN_IDENTITY="Developer ID Application"
+    HARDENED=YES
+    echo "==> Checking for a Developer ID Application certificate"
+    if ! security find-identity -v -p codesigning | grep -q "Developer ID Application"; then
+        echo "error: no 'Developer ID Application' certificate found in the keychain." >&2
+        echo "       This needs an ACTIVE Apple Developer Program membership — an expired" >&2
+        echo "       one drops you to a free 'Personal Team', which cannot create this" >&2
+        echo "       certificate or notarize at all. Check developer.apple.com/account." >&2
+        echo "" >&2
+        echo "       To ship without notarization anyway (Gatekeeper will warn users):" >&2
+        echo "           $0 $VERSION --adhoc" >&2
+        exit 1
+    fi
 fi
 
-echo "==> Building $VERSION (universal, hardened runtime)"
+echo "==> Building $VERSION (universal)"
 # -destination 'generic/platform=macOS' is what makes this universal. Without it
 # xcodebuild builds only the host architecture, which is how v1.2.1 shipped
 # arm64-only and left Intel Macs unable to run it.
@@ -59,16 +88,20 @@ echo "==> Building $VERSION (universal, hardened runtime)"
 # Notarization rejects hardened-runtime builds that carry it.
 #
 # ENABLE_HARDENED_RUNTIME=YES and --timestamp are both required by notarization.
+# No `clean` action: CONFIGURATION_BUILD_DIR is a fresh mktemp dir every run, so
+# the products are new by construction. Passing `clean` alongside -destination and
+# a custom build dir also makes xcodebuild fail with "Supported platforms for the
+# buildables in the current scheme is empty".
 xcodebuild -project "$PROJECT" -scheme "$SCHEME" \
     -configuration Release \
     -destination 'generic/platform=macOS' \
-    clean build \
+    build \
     CONFIGURATION_BUILD_DIR="$BUILD_DIR" \
-    CODE_SIGN_IDENTITY="Developer ID Application" \
+    CODE_SIGN_IDENTITY="$SIGN_IDENTITY" \
     CODE_SIGN_STYLE=Manual \
     DEVELOPMENT_TEAM="" \
     PROVISIONING_PROFILE_SPECIFIER="" \
-    ENABLE_HARDENED_RUNTIME=YES \
+    ENABLE_HARDENED_RUNTIME="$HARDENED" \
     CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
     OTHER_CODE_SIGN_FLAGS="--timestamp" \
     | tail -3
@@ -103,21 +136,30 @@ echo "==> Packaging"
 # ditto, not `zip` — it preserves the bundle's symlinks and extended attributes.
 ( cd "$BUILD_DIR" && ditto -c -k --keepParent "$APP_NAME" "$ZIP" )
 
-echo "==> Submitting to Apple for notarization (this usually takes 1-5 minutes)"
-xcrun notarytool submit "$BUILD_DIR/$ZIP" --keychain-profile "$KEYCHAIN_PROFILE" --wait
+if [[ "$ADHOC" == no ]]; then
+    echo "==> Submitting to Apple for notarization (this usually takes 1-5 minutes)"
+    xcrun notarytool submit "$BUILD_DIR/$ZIP" --keychain-profile "$KEYCHAIN_PROFILE" --wait
 
-echo "==> Stapling the notarization ticket to the app"
-# Staple the .app, then re-zip: the ticket attaches to the bundle, not the zip,
-# so the zip submitted above does not contain it.
-xcrun stapler staple "$APP"
-rm -f "$BUILD_DIR/$ZIP"
-( cd "$BUILD_DIR" && ditto -c -k --keepParent "$APP_NAME" "$ZIP" )
+    echo "==> Stapling the notarization ticket to the app"
+    # Staple the .app, then re-zip: the ticket attaches to the bundle, not the zip,
+    # so the zip submitted above does not contain it.
+    xcrun stapler staple "$APP"
+    rm -f "$BUILD_DIR/$ZIP"
+    ( cd "$BUILD_DIR" && ditto -c -k --keepParent "$APP_NAME" "$ZIP" )
 
-echo "==> Verifying Gatekeeper accepts the stapled app"
-xcrun stapler validate "$APP"
-spctl -a -vvv -t exec "$APP"
+    echo "==> Verifying Gatekeeper accepts the stapled app"
+    xcrun stapler validate "$APP"
+    spctl -a -vvv -t exec "$APP"
+else
+    echo "==> Skipping notarization (--adhoc)"
+    echo "    Recording what a user will actually hit, so it is not a surprise:"
+    spctl -a -vvv -t exec "$APP" 2>&1 | sed 's/^/    /' || true
+fi
 
 cp "$BUILD_DIR/$ZIP" "./$ZIP"
 echo
 echo "Done: ./$ZIP"
+if [[ "$ADHOC" == yes ]]; then
+    echo "NOTE: not notarized. Users must right-click -> Open the first time."
+fi
 echo "Attach it with:  gh release create v$VERSION ./$ZIP --title \"v$VERSION\" --notes-file <notes.md>"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,10 +32,22 @@ if [[ -z "$VERSION" ]]; then
     exit 2
 fi
 
+# VERSION is interpolated into the zip name and the copy destination, so reject
+# anything that isn't a plain version before it can write outside the repo.
+if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+)*([A-Za-z0-9.-]*)$ ]]; then
+    echo "error: '$VERSION' doesn't look like a version (expected e.g. 1.2.3)." >&2
+    exit 2
+fi
+
+# All project paths below are relative, so run from the repo root regardless of
+# where the caller invoked this from.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 PROJECT="Translate Menu.xcodeproj"
 SCHEME="Translate Menu"
 APP_NAME="Translate Menu.app"
 BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
 ZIP="TranslateMenu-${VERSION}.zip"
 KEYCHAIN_PROFILE="notary"
 
@@ -45,10 +57,16 @@ if [[ -d /Applications/Xcode.app ]]; then
     export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 fi
 
-echo "==> Checking the version in the project matches $VERSION"
-PROJECT_VERSION=$(grep -m1 'MARKETING_VERSION' "$PROJECT/project.pbxproj" | sed 's/.*= *//; s/;//')
-if [[ "$PROJECT_VERSION" != "$VERSION" ]]; then
-    echo "error: MARKETING_VERSION is $PROJECT_VERSION but you asked for $VERSION." >&2
+echo "==> Checking every build configuration is at $VERSION"
+# Check ALL MARKETING_VERSION entries, not just the first. There is one per build
+# configuration (Debug and Release), and they can drift apart — bumping only one
+# would otherwise pass this check while building the other. Quotes are stripped
+# because Xcode wraps values containing punctuation (e.g. "1.2.3-beta").
+PROJECT_VERSIONS=$(grep 'MARKETING_VERSION' "$PROJECT/project.pbxproj" \
+    | sed 's/.*= *//; s/;//; s/"//g' | sort -u)
+if [[ "$PROJECT_VERSIONS" != "$VERSION" ]]; then
+    echo "error: MARKETING_VERSION does not match $VERSION in every configuration." >&2
+    echo "       Found: $(echo "$PROJECT_VERSIONS" | tr '\n' ' ')" >&2
     echo "       Bump MARKETING_VERSION in both build configurations first." >&2
     exit 1
 fi
@@ -118,9 +136,24 @@ for required in x86_64 arm64; do
     fi
 done
 
-if codesign -d --entitlements - --xml "$APP" 2>/dev/null | plutil -p - | grep -q "get-task-allow"; then
+# Read the entitlements once into a variable rather than grepping a pipeline.
+# A pipeline here would hide failure: `if codesign ... | grep -q x` is exempt from
+# set -e, so if codesign produced nothing the grep would simply not match and the
+# check would silently PASS. Capturing first lets us tell "no debug entitlement"
+# apart from "couldn't read the entitlements at all".
+ENTITLEMENTS=$(codesign -d --entitlements - --xml "$APP" 2>/dev/null || true)
+if [[ -z "$ENTITLEMENTS" ]]; then
+    echo "error: could not read entitlements from the built app." >&2
+    echo "       Refusing to ship something we cannot inspect." >&2
+    exit 1
+fi
+if grep -q "get-task-allow" <<<"$ENTITLEMENTS"; then
     echo "error: the app carries com.apple.security.get-task-allow (debug entitlement)." >&2
     echo "       Notarization will reject this. Is CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO set?" >&2
+    exit 1
+fi
+if ! grep -q "com.apple.security.app-sandbox" <<<"$ENTITLEMENTS"; then
+    echo "error: the app is not sandboxed. Expected com.apple.security.app-sandbox." >&2
     exit 1
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Build, notarize, staple and package a release build of Translate Menu.
+#
+# Usage:  scripts/release.sh 1.2.3
+#
+# Prerequisites (one-time, see README "Cutting a release"):
+#   - A "Developer ID Application" certificate in the login keychain
+#   - A notarytool keychain profile named "notary":
+#       xcrun notarytool store-credentials notary --apple-id <you> --team-id <TEAM> --password <app-specific-password>
+#
+# Every flag below is load-bearing. See the comments before removing any.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+    echo "usage: $0 <version>   (e.g. $0 1.2.3)" >&2
+    exit 2
+fi
+
+PROJECT="Translate Menu.xcodeproj"
+SCHEME="Translate Menu"
+APP_NAME="Translate Menu.app"
+BUILD_DIR="$(mktemp -d)"
+ZIP="TranslateMenu-${VERSION}.zip"
+KEYCHAIN_PROFILE="notary"
+
+# This machine's xcode-select may point at CommandLineTools, where xcodebuild
+# does not exist. Prefer a real Xcode if one is installed.
+if [[ -d /Applications/Xcode.app ]]; then
+    export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+fi
+
+echo "==> Checking the version in the project matches $VERSION"
+PROJECT_VERSION=$(grep -m1 'MARKETING_VERSION' "$PROJECT/project.pbxproj" | sed 's/.*= *//; s/;//')
+if [[ "$PROJECT_VERSION" != "$VERSION" ]]; then
+    echo "error: MARKETING_VERSION is $PROJECT_VERSION but you asked for $VERSION." >&2
+    echo "       Bump MARKETING_VERSION in both build configurations first." >&2
+    exit 1
+fi
+
+echo "==> Checking for a Developer ID Application certificate"
+if ! security find-identity -v -p codesigning | grep -q "Developer ID Application"; then
+    echo "error: no 'Developer ID Application' certificate found in the keychain." >&2
+    echo "       Without it the app is only ad-hoc signed and Gatekeeper will reject it" >&2
+    echo "       on other people's Macs. Create one at developer.apple.com under" >&2
+    echo "       Certificates > + > Developer ID Application, then download and open it." >&2
+    exit 1
+fi
+
+echo "==> Building $VERSION (universal, hardened runtime)"
+# -destination 'generic/platform=macOS' is what makes this universal. Without it
+# xcodebuild builds only the host architecture, which is how v1.2.1 shipped
+# arm64-only and left Intel Macs unable to run it.
+#
+# CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO strips com.apple.security.get-task-allow,
+# the debug entitlement that lets a debugger attach. v1.2.1 shipped with it.
+# Notarization rejects hardened-runtime builds that carry it.
+#
+# ENABLE_HARDENED_RUNTIME=YES and --timestamp are both required by notarization.
+xcodebuild -project "$PROJECT" -scheme "$SCHEME" \
+    -configuration Release \
+    -destination 'generic/platform=macOS' \
+    clean build \
+    CONFIGURATION_BUILD_DIR="$BUILD_DIR" \
+    CODE_SIGN_IDENTITY="Developer ID Application" \
+    CODE_SIGN_STYLE=Manual \
+    DEVELOPMENT_TEAM="" \
+    PROVISIONING_PROFILE_SPECIFIER="" \
+    ENABLE_HARDENED_RUNTIME=YES \
+    CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
+    OTHER_CODE_SIGN_FLAGS="--timestamp" \
+    | tail -3
+
+APP="$BUILD_DIR/$APP_NAME"
+
+echo "==> Verifying the build before shipping it"
+ARCHS=$(lipo -archs "$APP/Contents/MacOS/Translate Menu")
+echo "    architectures: $ARCHS"
+for required in x86_64 arm64; do
+    if [[ "$ARCHS" != *"$required"* ]]; then
+        echo "error: $required missing — this build is not universal." >&2
+        exit 1
+    fi
+done
+
+if codesign -d --entitlements - --xml "$APP" 2>/dev/null | plutil -p - | grep -q "get-task-allow"; then
+    echo "error: the app carries com.apple.security.get-task-allow (debug entitlement)." >&2
+    echo "       Notarization will reject this. Is CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO set?" >&2
+    exit 1
+fi
+
+BUILT_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$APP/Contents/Info.plist")
+if [[ "$BUILT_VERSION" != "$VERSION" ]]; then
+    echo "error: built app reports version $BUILT_VERSION, expected $VERSION." >&2
+    exit 1
+fi
+echo "    version:       $BUILT_VERSION"
+echo "    signature:     $(codesign -dv --verbose=2 "$APP" 2>&1 | grep '^Authority' | head -1 | sed 's/Authority=//')"
+
+echo "==> Packaging"
+# ditto, not `zip` — it preserves the bundle's symlinks and extended attributes.
+( cd "$BUILD_DIR" && ditto -c -k --keepParent "$APP_NAME" "$ZIP" )
+
+echo "==> Submitting to Apple for notarization (this usually takes 1-5 minutes)"
+xcrun notarytool submit "$BUILD_DIR/$ZIP" --keychain-profile "$KEYCHAIN_PROFILE" --wait
+
+echo "==> Stapling the notarization ticket to the app"
+# Staple the .app, then re-zip: the ticket attaches to the bundle, not the zip,
+# so the zip submitted above does not contain it.
+xcrun stapler staple "$APP"
+rm -f "$BUILD_DIR/$ZIP"
+( cd "$BUILD_DIR" && ditto -c -k --keepParent "$APP_NAME" "$ZIP" )
+
+echo "==> Verifying Gatekeeper accepts the stapled app"
+xcrun stapler validate "$APP"
+spctl -a -vvv -t exec "$APP"
+
+cp "$BUILD_DIR/$ZIP" "./$ZIP"
+echo
+echo "Done: ./$ZIP"
+echo "Attach it with:  gh release create v$VERSION ./$ZIP --title \"v$VERSION\" --notes-file <notes.md>"


### PR DESCRIPTION
Cutting v1.2.3 surfaced two defects in how releases have been built — both of which are live in v1.2.1 today.

## What's wrong with the current releases

**v1.2.1 is arm64-only.** The project is configured for `ARCHS = arm64 x86_64`, but `xcodebuild` builds only the host architecture unless you pass `-destination 'generic/platform=macOS'`. So the published binary (73 downloads) cannot run on an Intel Mac at all. Verified by `lipo -archs` against the downloaded release asset.

**v1.2.1 ships the `get-task-allow` debug entitlement**, which permits a debugger to attach to the app. Stripping it needs `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO`, and notarization outright rejects hardened-runtime builds that carry it.

**v1.2.1 is ad-hoc signed and not notarized.** `spctl` rejects it, so all 73 downloads had to right-click→Open to get past Gatekeeper.

Neither of the first two is visible from the `xcodebuild` invocation, and both fail silently — you only discover them by inspecting the artifact afterwards. That's what this script is for.

## What this adds

`scripts/release.sh <version>` builds, notarizes, staples and packages a release, and **refuses to continue** unless:

- the binary is universal (checks `lipo -archs` for both `x86_64` and `arm64`)
- it carries no `get-task-allow`
- the built `CFBundleShortVersionString` matches the requested version
- `MARKETING_VERSION` in the project matches too
- a real Developer ID Application certificate exists — not an App Store distribution cert, which won't work for direct download

Plus a README section documenting the one-time notarization setup.

## Verified

- `bash -n` clean
- Run without a Developer ID cert present, it fails with an actionable message rather than silently producing an ad-hoc build
- A 1.2.3 build with these flags produces `x86_64 arm64`, no `get-task-allow`, sandbox and network entitlements intact

## Note

This does not itself cut v1.2.3 — that's blocked on a Developer ID certificate and notarytool credentials, which only @zetxek can set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)