### PR TITLE
Add a customizable global shortcut with a Settings window (closes #3)

### DIFF
--- a/Docs/superpowers/specs/2026-07-16-global-shortcut-design.md
+++ b/Docs/superpowers/specs/2026-07-16-global-shortcut-design.md
@@ -1,0 +1,160 @@
+# Global Customizable Keyboard Shortcut — Design
+
+**Issue:** [#3](https://github.com/zetxek/osx-menubar-translate/issues/3) — "Keyboard shortcut to access the translate window in menu bar", originally requested by @feppos0 in #2 (2019).
+
+**Goal:** Let the user press a keyboard shortcut from anywhere in macOS to open the translate popover, and choose that shortcut themselves in a Settings window.
+
+---
+
+## Decisions made during brainstorming
+
+| Decision | Choice | Why |
+|---|---|---|
+| Default shortcut | **None — opt-in** | Global hotkeys are scarce shared real estate. Claiming one at install could silently break a combo the user already relies on, without their consent. |
+| Settings UI | **AppKit, built in code** | Matches the existing AppKit codebase. No xib, because the recorder needs a custom `NSView` subclass anyway and xibs review badly in diffs. |
+| Hotkey registration | **Carbon `RegisterEventHotKey`** | Works inside the sandbox with no permission prompt, and consumes the keystroke. |
+
+### Why not `NSEvent.addGlobalMonitorForEvents`
+
+The app already uses `EventMonitor` (a global `NSEvent` monitor) for outside-click detection, so it would be the familiar choice. It is the wrong one here for two reasons:
+
+1. It requires Accessibility permission — a scary system prompt plus a trip to System Settings, for a convenience feature.
+2. **It cannot consume the event.** The keystroke would still reach the frontmost app, so the shortcut would open the translator *and* type into whatever the user was doing.
+
+The second is disqualifying.
+
+### Why not sindresorhus/KeyboardShortcuts
+
+It is good, and would supply a polished recorder for far less code. It would also be this project's first-ever dependency, for something that is roughly 150 lines to do directly. Not worth the precedent here.
+
+---
+
+## Architecture
+
+Four new files, each with one responsibility.
+
+### `GlobalShortcut.swift` — the value type
+
+```swift
+struct GlobalShortcut: Equatable {
+    let keyCode: UInt16
+    let modifiers: NSEvent.ModifierFlags
+}
+```
+
+Responsibilities:
+- **Validation.** Rejects any combination without at least one of `.command`, `.option`, `.control`. See "The bare-key hazard" below.
+- **Display string.** `⌥⌘T`, for the Settings UI.
+- **Persistence.** Encode to / decode from `UserDefaults`.
+- **Carbon translation.** Converts `NSEvent.ModifierFlags` to Carbon's `cmdKey`/`optionKey`/`controlKey`/`shiftKey` bitmask.
+
+Pure: no UI, no Carbon calls, no global state. This is the only piece that is genuinely unit-testable, and it deliberately holds the logic most worth testing.
+
+### `HotKeyCenter.swift` — the Carbon wrapper
+
+```swift
+final class HotKeyCenter {
+    func register(_ shortcut: GlobalShortcut, handler: @escaping () -> Void) throws
+    func unregister()
+}
+```
+
+The only file that knows Carbon exists. Owns the `EventHotKeyRef` and the installed event handler, and unregisters on `deinit`. Throws when `RegisterEventHotKey` returns a non-zero `OSStatus` so the caller can report a conflict.
+
+### `ShortcutRecorderView.swift` — the recorder
+
+An `NSView` subclass that becomes first responder, captures one `keyDown`, and reports a `GlobalShortcut` via a callback. Draws the current shortcut, or a "Click to record" prompt.
+
+Knows nothing about Carbon or persistence — it turns keystrokes into values.
+
+Behaviour:
+- Click → enters recording state.
+- A valid combination → reports it, exits recording.
+- An invalid combination (no `cmd`/`opt`/`ctrl`) → stays recording, shows a hint.
+- `Escape` → cancels, leaves the existing shortcut untouched.
+
+### `SettingsWindowController.swift` — the window
+
+Builds a small `NSWindow` in code: a label, the recorder, a Clear button, and a status line for errors. Owns no logic beyond wiring the recorder's callback to persistence and re-registration.
+
+### Changes to `AppDelegate.swift`
+
+- Add a "Settings…" item to `statusMenu`.
+- Own the `HotKeyCenter`.
+- On launch: read the saved shortcut, register it if present.
+- The handler calls the existing `statusItemButtonActivated` toggle path — not a new one.
+
+---
+
+## Data flow
+
+```
+Launch
+  UserDefaults → GlobalShortcut? → HotKeyCenter.register { toggle popover }
+
+Recording
+  keyDown → ShortcutRecorderView → GlobalShortcut
+          → validate → UserDefaults
+          → HotKeyCenter.unregister() → register(new)
+          → success or error shown in the window
+
+Clear
+  HotKeyCenter.unregister() → remove from UserDefaults
+```
+
+---
+
+## The bare-key hazard
+
+This is the one way the feature can go badly wrong, so it is worth stating plainly.
+
+A global hotkey with no modifier fires on **every press of that key, in every application**. If the user records `T` alone, pressing `t` while writing an email would open the translator over their message. Shift alone is not enough either — `shift+T` is just a capital T.
+
+Therefore `GlobalShortcut` refuses to exist without at least one of `.command`, `.option`, `.control`. Validation lives in the value type rather than the recorder view so it cannot be bypassed by a future caller, and so it is testable without a UI.
+
+Function keys (F1–F20) are a legitimate exception in principle — they are not typing keys. They are **out of scope**: allowing them means a second validation path for marginal benefit. If someone asks, revisit then.
+
+---
+
+## Error handling
+
+| Situation | Behaviour |
+|---|---|
+| `RegisterEventHotKey` fails (combo owned by another app) | `HotKeyCenter.register` throws; Settings shows "⌥⌘T is already in use by another app". The previous shortcut stays registered. |
+| Recorded combo has no `cmd`/`opt`/`ctrl` | Recorder refuses, shows "Add ⌘, ⌥ or ⌃". Nothing is saved. |
+| `UserDefaults` holds corrupt or partial data | Decode returns `nil`; treated as "no shortcut set". No crash, no migration. |
+| No shortcut set (default) | Nothing is registered. The app behaves exactly as it does today. |
+
+---
+
+## Testing
+
+**The repo has no test target.** The XCUITest work from an earlier session is still sitting in `stash@{0}` and was never landed. Adding a test target is a larger decision than this feature warrants, so this ships with manual verification.
+
+`GlobalShortcut` is nevertheless designed pure, so it *can* be unit-tested the moment a target exists — and it is where the logic worth testing lives (validation, display string, defaults round-trip).
+
+Manual verification checklist:
+
+- [ ] Record `⌥⌘T`; it displays as `⌥⌘T`.
+- [ ] With another app focused, `⌥⌘T` opens the popover with the input focused.
+- [ ] Pressing it again closes the popover.
+- [ ] The keystroke does **not** reach the previously focused app.
+- [ ] Quit and relaunch: the shortcut still works.
+- [ ] Clear: the shortcut stops working, and stays cleared across a relaunch.
+- [ ] Try recording `T` alone → refused with a hint.
+- [ ] Try recording a combo another app owns (e.g. `⌘Space`) → error shown, previous shortcut still works.
+- [ ] With no shortcut set, the app behaves exactly as before.
+
+---
+
+## Scope
+
+**In:** one shortcut, a Settings window containing only that, persistence, validation, conflict reporting.
+
+**Out:** other preferences; a first-run prompt; function-key support; multiple shortcuts; a shortcut to translate the current selection directly.
+
+---
+
+## Note on branching
+
+This branches from `master`, but [PR #18](https://github.com/zetxek/osx-menubar-translate/pull/18) (Start at Login) also adds an item to `statusMenu` in `AppDelegate.applicationDidFinishLaunching`. Whichever merges second will need a small conflict resolution there. The conflict is limited to menu-item insertion order.

--- a/Docs/superpowers/specs/2026-07-16-translate-selection-design.md
+++ b/Docs/superpowers/specs/2026-07-16-translate-selection-design.md
@@ -1,0 +1,142 @@
+# Translate the Selection on Shortcut — Design
+
+**Goal:** One shortcut. Press it with text selected and the popover opens already translating that text; press it with nothing selected and it opens empty, exactly as today.
+
+This unifies the global shortcut (#3, PR #19) with what the Services menu entry already does, so there is one key to learn rather than two.
+
+---
+
+## What the spike established
+
+A throwaway spike ran inside the real sandboxed app, because none of this can be answered from an unsandboxed shell. Findings:
+
+| Question | Answer |
+|---|---|
+| Can a **sandboxed** app be granted Accessibility? | **Yes.** "Translate Menu" appears in System Settings → Privacy & Security → Accessibility with a toggle. The sandbox is not a blocker. |
+| Does AX work in Chromium apps? | **Yes.** Vivaldi advertises `AXSelectedText` and returns it. |
+| What happens with no grant? | AX returns `-25204` (`kAXErrorCannotComplete`) and synthetic events are **silently dropped**. Nothing errors — it just does nothing. |
+
+Two corrections the spike forced, recorded so they are not repeated:
+
+- An earlier reading of `AXIsProcessTrusted: true` was **inherited trust** — the binary had been launched as a child of an already-trusted shell. Launched properly it reports `false`. Any future trust check must be done on a LaunchServices-launched app.
+- `-25212` is `kAXErrorNoValue` ("attribute exists, empty right now"), **not** `kAXErrorAttributeUnsupported` (`-25205`). Misreading it produced the false conclusion that Chromium lacks AX selection support, which nearly bought us a cmd+C fallback we do not need.
+
+---
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Permission | **Opt-in, default off** | Off = today's behaviour and no prompt ever. Users who only want a translate window never pay for a feature they did not ask for. |
+| Read method | **AX only** | The spike showed AX covers native *and* Chromium. A cmd+C fallback would add a second code path, a polling race, and clipboard damage to solve a problem that does not exist. |
+| Clipboard | **Never touched** | Follows from AX-only. |
+| Services entry | **Kept** | Free, needs no permission, and remains the answer for anyone who declines Accessibility. |
+
+### Why not simply put a shortcut on the Service
+
+A Service with `NSSendTypes` is **disabled when nothing is selected**, so a Services shortcut cannot open the translator on an empty selection. It therefore cannot be the single unified shortcut. It stays as a complement.
+
+---
+
+## Architecture
+
+### `SelectionReader.swift` — new, the only file that touches Accessibility
+
+```swift
+enum SelectionReader {
+    static var isPermitted: Bool          // AXIsProcessTrusted()
+    static func requestPermission()       // AXIsProcessTrustedWithOptions(prompt:)
+    static func readSelection() -> String?
+}
+```
+
+`readSelection()`:
+1. Find the frontmost app. **Skip if it is us** — our own popover's selection is not what the user means.
+2. `AXUIElementCreateApplication(pid)` → `kAXFocusedUIElementAttribute` → `kAXSelectedTextAttribute`.
+3. Clean the result (below).
+4. Return nil for empty, so the caller cannot tell "no selection" from "nothing useful".
+
+Every failure returns nil. There is no error surface: an unreadable selection means the popover opens empty, which is the pre-existing behaviour.
+
+### `Preferences.swift` — new, one pure value
+
+```swift
+enum Preferences {
+    static func translateSelection(in: UserDefaults = .standard) -> Bool
+    static func setTranslateSelection(_ on: Bool, in: UserDefaults = .standard)
+}
+```
+
+Pure and injectable, so it tests in the existing suite alongside `GlobalShortcut`.
+
+### `AppDelegate.toggleFromShortcut()` — one branch added
+
+```swift
+if popover.isShown { closePopover(sender: nil); return }
+if Preferences.translateSelection(), let text = SelectionReader.readSelection() {
+    translateViewController.loadText(text: text)
+}
+showPopover(sender: nil)
+```
+
+With the setting off, this is byte-for-byte today's behaviour.
+
+### `SettingsWindowController` — one checkbox
+
+"Translate selected text" plus a status line. Ticking it when Accessibility is not granted prompts, and the status line explains that macOS must be told to allow it, with a button that opens the pane. The checkbox reflects the stored preference; the status line reflects reality. **The two are kept separate on purpose** — a ticked box that silently does nothing is exactly the failure mode being avoided.
+
+---
+
+## Cleaning the selection
+
+Chromium returns `￼` (U+FFFC, object replacement) for inline images, and a `cmd+A` selection drags in page chrome. So:
+
+- Strip U+FFFC.
+- Collapse runs of whitespace/newlines into single spaces.
+- Trim.
+- **Cap at 2000 characters.** The text rides in the Google Translate URL; an unbounded selection would build an absurd URL. 2000 is comfortably inside what the endpoint accepts.
+- Empty after cleaning → nil.
+
+This is pure string handling, so it lives in a testable function rather than inline in the AX code.
+
+---
+
+## Error handling
+
+| Situation | Behaviour |
+|---|---|
+| Setting off | No AX call, no prompt, today's behaviour exactly. |
+| Setting on, permission not granted | Popover opens empty. Settings shows the permission is missing and offers to open the pane. |
+| Focused element has no `AXSelectedText` | Opens empty. Normal for non-text UI. |
+| Selection empty or whitespace | Opens empty. |
+| Frontmost app is us | No read attempted. |
+
+Nothing here is an error dialog. The failure mode of every path is "opens empty", which is what the app did before this feature.
+
+---
+
+## Testing
+
+Unit tests join the existing `Translate MenuTests` target:
+
+- `Preferences`: default is **off**; round-trips; a corrupt value reads as off.
+- Selection cleaning: strips U+FFFC; collapses whitespace; trims; caps at 2000; empty → nil.
+
+`SelectionReader.readSelection()` itself is not unit-testable — it needs a live AX session, a frontmost app and a granted permission. It is deliberately kept thin for that reason: the logic worth testing (cleaning, preference) sits either side of it.
+
+Manual verification requires the Accessibility toggle to be granted by hand:
+
+- [ ] Setting off: shortcut opens empty even with text selected.
+- [ ] Setting on, permission granted, text selected in TextEdit → opens translating it.
+- [ ] Same in Vivaldi (Chromium path).
+- [ ] Nothing selected → opens empty.
+- [ ] The clipboard is unchanged throughout.
+- [ ] Setting on, permission denied → opens empty, Settings explains why.
+
+---
+
+## Scope
+
+**In:** one checkbox, AX read, cleaning, the permission explanation.
+
+**Out:** cmd+C fallback; reading selections from apps with no AX support; translating without opening the popover; a first-run prompt.

--- a/Translate Menu.xcodeproj/project.pbxproj
+++ b/Translate Menu.xcodeproj/project.pbxproj
@@ -16,12 +16,25 @@
 		0C660F7BC3B445480E693D12 /* HotKeyCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */; };
 		15BA783BB0F7C25D1A25CC5F /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */; };
 		5077E61A2CEA791500EFBF1B /* TranslateWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5077E6192CEA791500EFBF1B /* TranslateWebView.swift */; };
+		6F814C345FFE89CECEE73347 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 182AC6B3CA0EEFCD8EB7D9E3 /* Cocoa.framework */; };
 		90CBC726DE69E6FCEF510C9E /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169A7A70292E08096E5B0C30 /* ShortcutRecorderView.swift */; };
 		A52AB4D43D4F4566A8EFDBD0 /* GlobalShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20929A7335927D0F6F1C42A1 /* GlobalShortcut.swift */; };
 		E7DE0D3B2344A24C00A9CBAD /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = E7DE0D3A2344A24C00A9CBAD /* MainMenu.xib */; };
+		FC32F2806B452F8026449579 /* GlobalShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054AE720EF7A4AABBCC1B727 /* GlobalShortcutTests.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		B2297D24076D8742426A0D75 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 78A6BBC31ADCB5EE00554D13 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 78A6BBCA1ADCB5EE00554D13;
+			remoteInfo = "Translate Menu";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		054AE720EF7A4AABBCC1B727 /* GlobalShortcutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GlobalShortcutTests.swift; path = "Translate MenuTests/GlobalShortcutTests.swift"; sourceTree = SOURCE_ROOT; };
 		0AC0CE141C81AEEF00305ACF /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = "Translate Menu/AppDelegate.swift"; sourceTree = SOURCE_ROOT; };
 		0AC0CE151C81AEEF00305ACF /* EventMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EventMonitor.swift; path = "Translate Menu/EventMonitor.swift"; sourceTree = SOURCE_ROOT; };
 		0AC0CE171C81AEEF00305ACF /* TranslateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TranslateViewController.swift; path = "Translate Menu/TranslateViewController.swift"; sourceTree = SOURCE_ROOT; };
@@ -29,6 +42,8 @@
 		0AC0CE1E1C81AEF700305ACF /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "Translate Menu/Images.xcassets"; sourceTree = SOURCE_ROOT; };
 		0AC0CE261C81B02B00305ACF /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		169A7A70292E08096E5B0C30 /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShortcutRecorderView.swift; path = "Translate Menu/ShortcutRecorderView.swift"; sourceTree = SOURCE_ROOT; };
+		182AC6B3CA0EEFCD8EB7D9E3 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		1C702E9D9F89868E3D4CD62C /* Translate MenuTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Translate MenuTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		20929A7335927D0F6F1C42A1 /* GlobalShortcut.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GlobalShortcut.swift; path = "Translate Menu/GlobalShortcut.swift"; sourceTree = SOURCE_ROOT; };
 		3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsWindowController.swift; path = "Translate Menu/SettingsWindowController.swift"; sourceTree = SOURCE_ROOT; };
 		5077E6192CEA791500EFBF1B /* TranslateWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateWebView.swift; sourceTree = SOURCE_ROOT; };
@@ -40,6 +55,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		442AA202976310C59C642321 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F814C345FFE89CECEE73347 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		78A6BBC81ADCB5EE00554D13 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -51,12 +74,30 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2F0CFD79733E42A7011B0893 /* Translate MenuTests */ = {
+			isa = PBXGroup;
+			children = (
+				054AE720EF7A4AABBCC1B727 /* GlobalShortcutTests.swift */,
+			);
+			name = "Translate MenuTests";
+			sourceTree = "<group>";
+		};
+		602D0B6C2B051EEC50E7C9DE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D33A3F6C6DD5E131AF1D62B1 /* OS X */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		78A6BBC21ADCB5EE00554D13 = {
 			isa = PBXGroup;
 			children = (
 				0AC0CE261C81B02B00305ACF /* WebKit.framework */,
 				78A6BBCD1ADCB5EE00554D13 /* Translate Menu */,
 				78A6BBCC1ADCB5EE00554D13 /* Products */,
+				602D0B6C2B051EEC50E7C9DE /* Frameworks */,
+				2F0CFD79733E42A7011B0893 /* Translate MenuTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -64,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				78A6BBCB1ADCB5EE00554D13 /* Translate Menu.app */,
+				1C702E9D9F89868E3D4CD62C /* Translate MenuTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -89,9 +131,35 @@
 			path = Quotes;
 			sourceTree = "<group>";
 		};
+		D33A3F6C6DD5E131AF1D62B1 /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				182AC6B3CA0EEFCD8EB7D9E3 /* Cocoa.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		12FEFCD23341F9B27D5CA006 /* Translate MenuTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 15CD5BBF22B184B9C570BDC5 /* Build configuration list for PBXNativeTarget "Translate MenuTests" */;
+			buildPhases = (
+				89BEC53BEA1E9E3F71F5E3AA /* Sources */,
+				442AA202976310C59C642321 /* Frameworks */,
+				A1DC4BF88B1B193E9BEEF7B6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				362FFDAB63F727E43EC622B8 /* PBXTargetDependency */,
+			);
+			name = "Translate MenuTests";
+			productName = "Translate MenuTests";
+			productReference = 1C702E9D9F89868E3D4CD62C /* Translate MenuTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		78A6BBCA1ADCB5EE00554D13 /* Translate Menu */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 78A6BBE51ADCB5EE00554D13 /* Build configuration list for PBXNativeTarget "Translate Menu" */;
@@ -140,6 +208,7 @@
 			projectRoot = "";
 			targets = (
 				78A6BBCA1ADCB5EE00554D13 /* Translate Menu */,
+				12FEFCD23341F9B27D5CA006 /* Translate MenuTests */,
 			);
 		};
 /* End PBXProject section */
@@ -152,6 +221,13 @@
 				0AC0CE1D1C81AEEF00305ACF /* TranslateViewController.xib in Resources */,
 				0AC0CE1F1C81AEF700305ACF /* Images.xcassets in Resources */,
 				E7DE0D3B2344A24C00A9CBAD /* MainMenu.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1DC4BF88B1B193E9BEEF7B6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -173,9 +249,45 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		89BEC53BEA1E9E3F71F5E3AA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC32F2806B452F8026449579 /* GlobalShortcutTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		362FFDAB63F727E43EC622B8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Translate Menu";
+			target = 78A6BBCA1ADCB5EE00554D13 /* Translate Menu */;
+			targetProxy = B2297D24076D8742426A0D75 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		3AD3843FCFC1F05A9E220D76 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.4;
+				PRODUCT_BUNDLE_IDENTIFIER = "info.adrianmoreno.Translate-MenuTests";
+				PRODUCT_MODULE_NAME = Translate_MenuTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Translate Menu.app/Contents/MacOS/Translate Menu";
+			};
+			name = Release;
+		};
 		78A6BBE31ADCB5EE00554D13 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -347,9 +459,37 @@
 			};
 			name = Release;
 		};
+		830862A41A7217DDB4620BF8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.4;
+				PRODUCT_BUNDLE_IDENTIFIER = "info.adrianmoreno.Translate-MenuTests";
+				PRODUCT_MODULE_NAME = Translate_MenuTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Translate Menu.app/Contents/MacOS/Translate Menu";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		15CD5BBF22B184B9C570BDC5 /* Build configuration list for PBXNativeTarget "Translate MenuTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AD3843FCFC1F05A9E220D76 /* Release */,
+				830862A41A7217DDB4620BF8 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		78A6BBC61ADCB5EE00554D13 /* Build configuration list for PBXProject "Translate Menu" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Translate Menu.xcodeproj/project.pbxproj
+++ b/Translate Menu.xcodeproj/project.pbxproj
@@ -14,9 +14,12 @@
 		0AC0CE1F1C81AEF700305ACF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AC0CE1E1C81AEF700305ACF /* Images.xcassets */; };
 		0AC0CE271C81B02B00305ACF /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AC0CE261C81B02B00305ACF /* WebKit.framework */; };
 		0C660F7BC3B445480E693D12 /* HotKeyCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */; };
+		0F43D88901CAC4D648CF0665 /* SelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 242DC78DB06713515350345F /* SelectionTests.swift */; };
 		15BA783BB0F7C25D1A25CC5F /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */; };
 		5077E61A2CEA791500EFBF1B /* TranslateWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5077E6192CEA791500EFBF1B /* TranslateWebView.swift */; };
+		5CD83229C3FD21330123EDAC /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46ECE0DDA3D7CD271824D9D /* Preferences.swift */; };
 		6F814C345FFE89CECEE73347 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 182AC6B3CA0EEFCD8EB7D9E3 /* Cocoa.framework */; };
+		740F51ADE06A48D439109FDB /* SelectionReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47EAD52718E7B08FDB8C014 /* SelectionReader.swift */; };
 		90CBC726DE69E6FCEF510C9E /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169A7A70292E08096E5B0C30 /* ShortcutRecorderView.swift */; };
 		A52AB4D43D4F4566A8EFDBD0 /* GlobalShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20929A7335927D0F6F1C42A1 /* GlobalShortcut.swift */; };
 		E7DE0D3B2344A24C00A9CBAD /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = E7DE0D3A2344A24C00A9CBAD /* MainMenu.xib */; };
@@ -45,13 +48,16 @@
 		182AC6B3CA0EEFCD8EB7D9E3 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		1C702E9D9F89868E3D4CD62C /* Translate MenuTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Translate MenuTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		20929A7335927D0F6F1C42A1 /* GlobalShortcut.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GlobalShortcut.swift; path = "Translate Menu/GlobalShortcut.swift"; sourceTree = SOURCE_ROOT; };
+		242DC78DB06713515350345F /* SelectionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelectionTests.swift; path = "Translate MenuTests/SelectionTests.swift"; sourceTree = SOURCE_ROOT; };
 		3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsWindowController.swift; path = "Translate Menu/SettingsWindowController.swift"; sourceTree = SOURCE_ROOT; };
 		5077E6192CEA791500EFBF1B /* TranslateWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateWebView.swift; sourceTree = SOURCE_ROOT; };
 		507C65442D1ABDF00074FB46 /* Translate Menu.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "Translate Menu.entitlements"; path = "Translate Menu/Translate Menu.entitlements"; sourceTree = SOURCE_ROOT; };
 		78A6BBCB1ADCB5EE00554D13 /* Translate Menu.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Translate Menu.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B47EAD52718E7B08FDB8C014 /* SelectionReader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelectionReader.swift; path = "Translate Menu/SelectionReader.swift"; sourceTree = SOURCE_ROOT; };
 		DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HotKeyCenter.swift; path = "Translate Menu/HotKeyCenter.swift"; sourceTree = SOURCE_ROOT; };
 		E7DE0D382344A22D00A9CBAD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "Translate Menu/Info.plist"; sourceTree = SOURCE_ROOT; };
 		E7DE0D3A2344A24C00A9CBAD /* MainMenu.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = MainMenu.xib; path = "Translate Menu/MainMenu.xib"; sourceTree = SOURCE_ROOT; };
+		F46ECE0DDA3D7CD271824D9D /* Preferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Preferences.swift; path = "Translate Menu/Preferences.swift"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +84,7 @@
 			isa = PBXGroup;
 			children = (
 				054AE720EF7A4AABBCC1B727 /* GlobalShortcutTests.swift */,
+				242DC78DB06713515350345F /* SelectionTests.swift */,
 			);
 			name = "Translate MenuTests";
 			sourceTree = "<group>";
@@ -126,6 +133,8 @@
 				DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */,
 				169A7A70292E08096E5B0C30 /* ShortcutRecorderView.swift */,
 				3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */,
+				F46ECE0DDA3D7CD271824D9D /* Preferences.swift */,
+				B47EAD52718E7B08FDB8C014 /* SelectionReader.swift */,
 			);
 			name = "Translate Menu";
 			path = Quotes;
@@ -246,6 +255,8 @@
 				0C660F7BC3B445480E693D12 /* HotKeyCenter.swift in Sources */,
 				90CBC726DE69E6FCEF510C9E /* ShortcutRecorderView.swift in Sources */,
 				15BA783BB0F7C25D1A25CC5F /* SettingsWindowController.swift in Sources */,
+				5CD83229C3FD21330123EDAC /* Preferences.swift in Sources */,
+				740F51ADE06A48D439109FDB /* SelectionReader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,6 +265,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FC32F2806B452F8026449579 /* GlobalShortcutTests.swift in Sources */,
+				0F43D88901CAC4D648CF0665 /* SelectionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Translate Menu.xcodeproj/project.pbxproj
+++ b/Translate Menu.xcodeproj/project.pbxproj
@@ -13,7 +13,11 @@
 		0AC0CE1D1C81AEEF00305ACF /* TranslateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AC0CE181C81AEEF00305ACF /* TranslateViewController.xib */; };
 		0AC0CE1F1C81AEF700305ACF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AC0CE1E1C81AEF700305ACF /* Images.xcassets */; };
 		0AC0CE271C81B02B00305ACF /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AC0CE261C81B02B00305ACF /* WebKit.framework */; };
+		0C660F7BC3B445480E693D12 /* HotKeyCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */; };
+		15BA783BB0F7C25D1A25CC5F /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */; };
 		5077E61A2CEA791500EFBF1B /* TranslateWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5077E6192CEA791500EFBF1B /* TranslateWebView.swift */; };
+		90CBC726DE69E6FCEF510C9E /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169A7A70292E08096E5B0C30 /* ShortcutRecorderView.swift */; };
+		A52AB4D43D4F4566A8EFDBD0 /* GlobalShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20929A7335927D0F6F1C42A1 /* GlobalShortcut.swift */; };
 		E7DE0D3B2344A24C00A9CBAD /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = E7DE0D3A2344A24C00A9CBAD /* MainMenu.xib */; };
 /* End PBXBuildFile section */
 
@@ -24,9 +28,13 @@
 		0AC0CE181C81AEEF00305ACF /* TranslateViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = TranslateViewController.xib; path = "Translate Menu/TranslateViewController.xib"; sourceTree = SOURCE_ROOT; };
 		0AC0CE1E1C81AEF700305ACF /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "Translate Menu/Images.xcassets"; sourceTree = SOURCE_ROOT; };
 		0AC0CE261C81B02B00305ACF /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		169A7A70292E08096E5B0C30 /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShortcutRecorderView.swift; path = "Translate Menu/ShortcutRecorderView.swift"; sourceTree = SOURCE_ROOT; };
+		20929A7335927D0F6F1C42A1 /* GlobalShortcut.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GlobalShortcut.swift; path = "Translate Menu/GlobalShortcut.swift"; sourceTree = SOURCE_ROOT; };
+		3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsWindowController.swift; path = "Translate Menu/SettingsWindowController.swift"; sourceTree = SOURCE_ROOT; };
 		5077E6192CEA791500EFBF1B /* TranslateWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateWebView.swift; sourceTree = SOURCE_ROOT; };
 		507C65442D1ABDF00074FB46 /* Translate Menu.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "Translate Menu.entitlements"; path = "Translate Menu/Translate Menu.entitlements"; sourceTree = SOURCE_ROOT; };
 		78A6BBCB1ADCB5EE00554D13 /* Translate Menu.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Translate Menu.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HotKeyCenter.swift; path = "Translate Menu/HotKeyCenter.swift"; sourceTree = SOURCE_ROOT; };
 		E7DE0D382344A22D00A9CBAD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "Translate Menu/Info.plist"; sourceTree = SOURCE_ROOT; };
 		E7DE0D3A2344A24C00A9CBAD /* MainMenu.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = MainMenu.xib; path = "Translate Menu/MainMenu.xib"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -72,6 +80,10 @@
 				5077E6192CEA791500EFBF1B /* TranslateWebView.swift */,
 				0AC0CE1E1C81AEF700305ACF /* Images.xcassets */,
 				E7DE0D382344A22D00A9CBAD /* Info.plist */,
+				20929A7335927D0F6F1C42A1 /* GlobalShortcut.swift */,
+				DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */,
+				169A7A70292E08096E5B0C30 /* ShortcutRecorderView.swift */,
+				3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */,
 			);
 			name = "Translate Menu";
 			path = Quotes;
@@ -154,6 +166,10 @@
 				0AC0CE1A1C81AEEF00305ACF /* EventMonitor.swift in Sources */,
 				0AC0CE191C81AEEF00305ACF /* AppDelegate.swift in Sources */,
 				0AC0CE1C1C81AEEF00305ACF /* TranslateViewController.swift in Sources */,
+				A52AB4D43D4F4566A8EFDBD0 /* GlobalShortcut.swift in Sources */,
+				0C660F7BC3B445480E693D12 /* HotKeyCenter.swift in Sources */,
+				90CBC726DE69E6FCEF510C9E /* ShortcutRecorderView.swift in Sources */,
+				15BA783BB0F7C25D1A25CC5F /* SettingsWindowController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Translate Menu.xcodeproj/xcshareddata/xcschemes/Translate Menu.xcscheme
+++ b/Translate Menu.xcodeproj/xcshareddata/xcschemes/Translate Menu.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "78A6BBCA1ADCB5EE00554D13"
+               BuildableName = "Translate Menu.app"
+               BlueprintName = "Translate Menu"
+               ReferencedContainer = "container:Translate Menu.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "12FEFCD23341F9B27D5CA006"
+               BuildableName = "Translate MenuTests.xctest"
+               BlueprintName = "Translate MenuTests"
+               ReferencedContainer = "container:Translate Menu.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "12FEFCD23341F9B27D5CA006"
+               BuildableName = "Translate MenuTests.xctest"
+               BlueprintName = "Translate MenuTests"
+               ReferencedContainer = "container:Translate Menu.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Translate Menu/AppDelegate.swift
+++ b/Translate Menu/AppDelegate.swift
@@ -44,6 +44,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let translateViewController = TranslateViewController(nibName: "TranslateViewController", bundle: nil)
     /// Global mouse click monitor, used to detect clicks outside the popover and auto-close it
     var eventMonitor: EventMonitor?
+    /// Registers the user's system-wide shortcut, if they have set one
+    private let hotKeyCenter = HotKeyCenter()
+    /// Kept alive so the window survives being closed and reopened
+    private var settingsWindowController: SettingsWindowController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Create the menu bar icon; isTemplate lets it adapt to light/dark menu bars automatically
@@ -82,10 +86,91 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
         statusMenu.item(at: 0)?.title = "Version \(version)"
 
+        // Settings first, so it and Start at Login sit together above the separator,
+        // with About/Quit below it. installStartAtLoginItem() inserts relative to the
+        // index installSettingsMenuItem() leaves behind, so the order here is load-bearing.
+        installSettingsMenuItem()
         installStartAtLoginItem()
+        registerSavedShortcut()
 
         // Register as a Services provider (matches the NSServices declaration in Info.plist)
         NSApplication.shared.servicesProvider = self
+    }
+
+    /// Adds "Settings…" to the right-click menu, above About.
+    private func installSettingsMenuItem() {
+        let item = NSMenuItem(title: "Settings…",
+                              action: #selector(showSettings),
+                              keyEquivalent: "")
+        item.target = self
+        // Index 1: directly under the version line, before About and Quit.
+        statusMenu.insertItem(item, at: 1)
+        statusMenu.insertItem(.separator(), at: 2)
+    }
+
+    /// Restores the user's shortcut at launch. There is no default: nothing is registered
+    /// until the user chooses a combination, because claiming a global hotkey they never
+    /// asked for could silently break one they already use.
+    private func registerSavedShortcut() {
+        guard let shortcut = GlobalShortcut.load() else { return }
+        do {
+            try hotKeyCenter.register(shortcut) { [weak self] in
+                self?.toggleFromShortcut()
+            }
+        } catch {
+            // Another app may have claimed the combination since it was saved. Leave it in
+            // defaults so Settings still shows what the user chose, and say why it is dead.
+            NSLog("AppDelegate: could not register \(shortcut.displayString): \(error)")
+        }
+    }
+
+    /// The shortcut behaves exactly like clicking the menu bar icon.
+    private func toggleFromShortcut() {
+        if popover.isShown {
+            closePopover(sender: nil)
+        } else {
+            showPopover(sender: nil)
+        }
+    }
+
+    /// Right-click menu: Settings…
+    @objc
+    private func showSettings() {
+        if settingsWindowController == nil {
+            settingsWindowController = SettingsWindowController(
+                shortcut: GlobalShortcut.load(),
+                applyShortcut: { [weak self] shortcut in
+                    self?.apply(shortcut)
+                },
+                clearShortcut: { [weak self] in
+                    self?.hotKeyCenter.unregister()
+                    GlobalShortcut.clear()
+                }
+            )
+        }
+        settingsWindowController?.present()
+    }
+
+    /// Registers a newly recorded shortcut and saves it. Returns a message to show the
+    /// user on failure, or nil on success.
+    private func apply(_ shortcut: GlobalShortcut) -> String? {
+        do {
+            try hotKeyCenter.register(shortcut) { [weak self] in
+                self?.toggleFromShortcut()
+            }
+        } catch {
+            // Registration failed, so don't save: defaults must never describe a shortcut
+            // that isn't actually live. Put the previous one back if there was one.
+            if let previous = GlobalShortcut.load() {
+                try? hotKeyCenter.register(previous) { [weak self] in
+                    self?.toggleFromShortcut()
+                }
+            }
+            return "\(shortcut.displayString) is already in use by another app."
+        }
+
+        shortcut.save()
+        return nil
     }
 
     /// Status item clicked: left-click toggles the popover, right-click (or control+left-click) shows the menu.
@@ -148,10 +233,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         showPopover(sender: nil)
     }
 
-    /// Adds the "Start at Login" toggle to the right-click menu, just under the version.
-    /// Does nothing before macOS 13: SMAppService doesn't exist there, and the app still
-    /// deploys back to 12.4. Users on 12.x can add the app to Login Items in System
-    /// Settings by hand, which is what this automates.
+    /// Adds the "Start at Login" toggle to the right-click menu, grouped with Settings…
+    /// above the separator. Does nothing before macOS 13: SMAppService doesn't exist
+    /// there, and the app still deploys back to 12.4. Users on 12.x can add the app to
+    /// Login Items in System Settings by hand, which is what this automates.
     private func installStartAtLoginItem() {
         guard #available(macOS 13.0, *) else { return }
 
@@ -159,7 +244,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                               action: #selector(toggleStartAtLogin(_:)),
                               keyEquivalent: "")
         item.target = self
-        statusMenu.insertItem(item, at: 1)
+        // Index 2: right after "Settings…", before the separator installSettingsMenuItem()
+        // left at that index. Assumes installSettingsMenuItem() has already run.
+        statusMenu.insertItem(item, at: 2)
         startAtLoginItem = item
 
         // The state can change outside the app (System Settings > General > Login Items),

--- a/Translate Menu/AppDelegate.swift
+++ b/Translate Menu/AppDelegate.swift
@@ -124,13 +124,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// The shortcut behaves exactly like clicking the menu bar icon.
+    /// The shortcut behaves like clicking the menu bar icon, and additionally translates
+    /// the current selection if the user has asked for that.
+    ///
+    /// The selection is read *before* showing the popover: showing it first would make us
+    /// the frontmost app and there would be no other app's selection left to read.
     private func toggleFromShortcut() {
         if popover.isShown {
             closePopover(sender: nil)
-        } else {
-            showPopover(sender: nil)
+            return
         }
+
+        if Preferences.translateSelection(), let text = SelectionReader.readSelection() {
+            translateViewController.loadText(text: text)
+        }
+
+        showPopover(sender: nil)
     }
 
     /// Right-click menu: Settings…

--- a/Translate Menu/AppDelegate.swift
+++ b/Translate Menu/AppDelegate.swift
@@ -119,7 +119,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         } catch {
             // Another app may have claimed the combination since it was saved. Leave it in
-            // defaults so Settings still shows what the user chose, and say why it is dead.
+            // defaults rather than clearing it — showSettings() checks hotKeyCenter.isRegistered
+            // against this and surfaces the failure there, instead of the window silently
+            // claiming a shortcut that isn't actually live.
             NSLog("AppDelegate: could not register \(shortcut.displayString): \(error)")
         }
     }
@@ -146,8 +148,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc
     private func showSettings() {
         if settingsWindowController == nil {
+            let saved = GlobalShortcut.load()
+            // A saved shortcut that failed to register at launch (its combination may
+            // have been claimed by another app since) would otherwise show as live with
+            // nothing actually registered behind it.
+            let initialError = (saved != nil && !hotKeyCenter.isRegistered)
+                ? "\(saved!.displayString) could not be registered — another app may already use it."
+                : nil
+
             settingsWindowController = SettingsWindowController(
-                shortcut: GlobalShortcut.load(),
+                shortcut: saved,
+                initialError: initialError,
                 applyShortcut: { [weak self] shortcut in
                     self?.apply(shortcut)
                 },
@@ -169,10 +180,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         } catch {
             // Registration failed, so don't save: defaults must never describe a shortcut
-            // that isn't actually live. Put the previous one back if there was one.
+            // that isn't actually live. Put the previous one back if there was one — and
+            // if that fails too (its own combination could have been claimed since), clear
+            // defaults rather than leave them pointing at a shortcut that isn't registered.
             if let previous = GlobalShortcut.load() {
-                try? hotKeyCenter.register(previous) { [weak self] in
-                    self?.toggleFromShortcut()
+                do {
+                    try hotKeyCenter.register(previous) { [weak self] in
+                        self?.toggleFromShortcut()
+                    }
+                } catch {
+                    GlobalShortcut.clear()
+                    return "\(shortcut.displayString) is already in use, and your previous "
+                        + "shortcut could no longer be restored either. Shortcut cleared."
                 }
             }
             return "\(shortcut.displayString) is already in use by another app."

--- a/Translate Menu/GlobalShortcut.swift
+++ b/Translate Menu/GlobalShortcut.swift
@@ -1,0 +1,167 @@
+/*
+* Copyright (c) 2015 Adrián Moreno Peña
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+import Carbon.HIToolbox
+import Cocoa
+
+/// A global keyboard shortcut: a key plus the modifiers held with it.
+///
+/// Pure value type — it knows nothing about Carbon registration or the UI, so the
+/// rules that matter (what counts as a legal shortcut, how it reads, how it round-trips
+/// through UserDefaults) live somewhere they can be reasoned about on their own.
+struct GlobalShortcut: Equatable {
+    let keyCode: UInt16
+    let modifiers: NSEvent.ModifierFlags
+
+    /// Modifiers that make a shortcut safe to register globally.
+    ///
+    /// At least one of these is required. Without a modifier the hotkey fires on *every*
+    /// press of that key in *every* app — record "T" and typing "t" in Mail would open
+    /// the translator over the message. Shift alone doesn't count: shift+T is a capital T.
+    private static let qualifyingModifiers: NSEvent.ModifierFlags = [.command, .option, .control]
+
+    /// Creates a shortcut, or nil if the combination isn't safe to register globally.
+    ///
+    /// Returning nil rather than trapping means callers must handle the invalid case, and
+    /// keeps the rule in one place — a recorder can't forget to check it.
+    init?(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) {
+        let relevant = modifiers.intersection(.deviceIndependentFlagsMask)
+        guard !relevant.intersection(Self.qualifyingModifiers).isEmpty else { return nil }
+
+        self.keyCode = keyCode
+        // Store only the modifiers that matter, so ⌘T recorded with Caps Lock on still
+        // equals ⌘T recorded without it.
+        self.modifiers = relevant.intersection([.command, .option, .control, .shift])
+    }
+
+    /// How the shortcut reads in the UI, e.g. `⌥⌘T`.
+    /// Ordered the way macOS orders modifiers everywhere else: ⌃⌥⇧⌘.
+    var displayString: String {
+        var out = ""
+        if modifiers.contains(.control) { out += "⌃" }
+        if modifiers.contains(.option) { out += "⌥" }
+        if modifiers.contains(.shift) { out += "⇧" }
+        if modifiers.contains(.command) { out += "⌘" }
+        return out + Self.keyName(for: keyCode)
+    }
+
+    // MARK: - Carbon
+
+    /// The modifier bitmask Carbon's RegisterEventHotKey expects. Carbon uses its own
+    /// constants rather than NSEvent's, so the two have to be translated explicitly.
+    var carbonModifiers: UInt32 {
+        var out: UInt32 = 0
+        if modifiers.contains(.command) { out |= UInt32(cmdKey) }
+        if modifiers.contains(.option) { out |= UInt32(optionKey) }
+        if modifiers.contains(.control) { out |= UInt32(controlKey) }
+        if modifiers.contains(.shift) { out |= UInt32(shiftKey) }
+        return out
+    }
+
+    // MARK: - Persistence
+
+    private static let keyCodeDefault = "globalShortcutKeyCode"
+    private static let modifiersDefault = "globalShortcutModifiers"
+
+    /// Reads the saved shortcut, or nil if none is set or the stored data no longer makes
+    /// sense. Anything unreadable is treated as "not set" rather than migrated or repaired —
+    /// the cost of a wrong guess here is a hotkey the user didn't ask for.
+    static func load(from defaults: UserDefaults = .standard) -> GlobalShortcut? {
+        guard defaults.object(forKey: keyCodeDefault) != nil,
+              defaults.object(forKey: modifiersDefault) != nil else { return nil }
+
+        let rawKey = defaults.integer(forKey: keyCodeDefault)
+        let rawModifiers = defaults.integer(forKey: modifiersDefault)
+        guard let keyCode = UInt16(exactly: rawKey), rawModifiers >= 0 else { return nil }
+
+        // Runs through init? so a stored value that fails today's validation is rejected
+        // rather than trusted.
+        return GlobalShortcut(keyCode: keyCode,
+                              modifiers: NSEvent.ModifierFlags(rawValue: UInt(rawModifiers)))
+    }
+
+    func save(to defaults: UserDefaults = .standard) {
+        defaults.set(Int(keyCode), forKey: Self.keyCodeDefault)
+        defaults.set(Int(modifiers.rawValue), forKey: Self.modifiersDefault)
+    }
+
+    static func clear(in defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: keyCodeDefault)
+        defaults.removeObject(forKey: modifiersDefault)
+    }
+
+    // MARK: - Key names
+
+    /// Keys whose glyph can't be derived from the keyboard layout (arrows, return, and
+    /// friends). Everything else is resolved live against the user's actual layout, so
+    /// that a French or Dvorak keyboard shows the key the user is really pressing.
+    private static let namedKeys: [UInt16: String] = [
+        UInt16(kVK_Return): "↩", UInt16(kVK_Tab): "⇥", UInt16(kVK_Space): "Space",
+        UInt16(kVK_Delete): "⌫", UInt16(kVK_ForwardDelete): "⌦", UInt16(kVK_Escape): "⎋",
+        UInt16(kVK_LeftArrow): "←", UInt16(kVK_RightArrow): "→",
+        UInt16(kVK_UpArrow): "↑", UInt16(kVK_DownArrow): "↓",
+        UInt16(kVK_Home): "↖", UInt16(kVK_End): "↘",
+        UInt16(kVK_PageUp): "⇞", UInt16(kVK_PageDown): "⇟",
+        UInt16(kVK_F1): "F1", UInt16(kVK_F2): "F2", UInt16(kVK_F3): "F3",
+        UInt16(kVK_F4): "F4", UInt16(kVK_F5): "F5", UInt16(kVK_F6): "F6",
+        UInt16(kVK_F7): "F7", UInt16(kVK_F8): "F8", UInt16(kVK_F9): "F9",
+        UInt16(kVK_F10): "F10", UInt16(kVK_F11): "F11", UInt16(kVK_F12): "F12",
+    ]
+
+    static func keyName(for keyCode: UInt16) -> String {
+        if let named = namedKeys[keyCode] { return named }
+        if let character = layoutCharacter(for: keyCode) { return character.uppercased() }
+        return "Key \(keyCode)"
+    }
+
+    /// Asks the current keyboard layout what character a key code produces, unmodified.
+    /// Returns nil for keys that produce nothing printable.
+    private static func layoutCharacter(for keyCode: UInt16) -> String? {
+        guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+              let pointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
+        else { return nil }
+
+        let data = Unmanaged<CFData>.fromOpaque(pointer).takeUnretainedValue() as Data
+        var deadKeyState: UInt32 = 0
+        var length = 0
+        var characters = [UniChar](repeating: 0, count: 4)
+
+        let status = data.withUnsafeBytes { raw -> OSStatus in
+            guard let layout = raw.bindMemory(to: UCKeyboardLayout.self).baseAddress else {
+                return OSStatus(paramErr)
+            }
+            return UCKeyTranslate(layout,
+                                  keyCode,
+                                  UInt16(kUCKeyActionDisplay),
+                                  0, // no modifiers: we want the key's own character
+                                  UInt32(LMGetKbdType()),
+                                  OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                                  &deadKeyState,
+                                  characters.count,
+                                  &length,
+                                  &characters)
+        }
+
+        guard status == noErr, length > 0 else { return nil }
+        let name = String(utf16CodeUnits: characters, count: length)
+        return name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : name
+    }
+}

--- a/Translate Menu/HotKeyCenter.swift
+++ b/Translate Menu/HotKeyCenter.swift
@@ -31,7 +31,9 @@ import Foundation
 /// popover and also type into whatever app the user was in. Apple never shipped a modern
 /// replacement for this API.
 ///
-/// This is the only type that knows Carbon exists.
+/// The only type that talks to Carbon's hotkey APIs. `GlobalShortcut` and
+/// `ShortcutRecorderView` also import `Carbon.HIToolbox`, but only for its keycode and
+/// modifier constants — this is the only one that calls `RegisterEventHotKey` and friends.
 final class HotKeyCenter {
     enum RegistrationError: Error {
         /// RegisterEventHotKey refused the combination — usually because another app
@@ -43,12 +45,23 @@ final class HotKeyCenter {
     private var eventHandler: EventHandlerRef?
     private var handler: (() -> Void)?
 
+    /// Whether a hotkey is currently registered and live. Lets a caller tell "nothing is
+    /// registered because the user hasn't set a shortcut" apart from "registration was
+    /// attempted and failed" without keeping its own shadow state.
+    var isRegistered: Bool { hotKeyRef != nil }
+
     /// Identifies our hotkey in the Carbon callback. Arbitrary, but must be stable.
     private static let signature: OSType = 0x4D42_5452 // 'MBTR'
     private let identifier: UInt32 = 1
 
     deinit {
         unregister()
+        // unregister() only removes the hotkey binding, not the Carbon event handler
+        // installed below — that has to go too, or its userData pointer (an unretained
+        // reference back to this instance) dangles and a stray event would use-after-free.
+        if let eventHandler {
+            RemoveEventHandler(eventHandler)
+        }
     }
 
     /// Registers `shortcut` system-wide, replacing any previously registered one.
@@ -96,8 +109,8 @@ final class HotKeyCenter {
                                  eventKind: UInt32(kEventHotKeyPressed))
 
         // Carbon is a C API with no notion of self, so pass an unretained pointer back to
-        // this instance. Unretained is safe because deinit removes the handler, so the
-        // callback cannot outlive the object it points at.
+        // this instance. Unretained is safe because deinit removes this handler (see
+        // above), so the callback cannot outlive the object it points at.
         let context = Unmanaged.passUnretained(self).toOpaque()
 
         InstallEventHandler(GetEventDispatcherTarget(), { _, event, userData in

--- a/Translate Menu/HotKeyCenter.swift
+++ b/Translate Menu/HotKeyCenter.swift
@@ -1,0 +1,128 @@
+/*
+* Copyright (c) 2015 Adrián Moreno Peña
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+import Carbon.HIToolbox
+import Foundation
+
+/// Registers one system-wide hotkey and calls a handler when it fires.
+///
+/// Uses Carbon's RegisterEventHotKey, which looks archaic but is still the right tool:
+/// it works inside the App Sandbox with no Accessibility permission, and it *consumes*
+/// the keystroke. The obvious alternative, NSEvent.addGlobalMonitorForEvents, needs
+/// Accessibility permission and cannot consume the event — the shortcut would open the
+/// popover and also type into whatever app the user was in. Apple never shipped a modern
+/// replacement for this API.
+///
+/// This is the only type that knows Carbon exists.
+final class HotKeyCenter {
+    enum RegistrationError: Error {
+        /// RegisterEventHotKey refused the combination — usually because another app
+        /// already owns it.
+        case unavailable(OSStatus)
+    }
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandler: EventHandlerRef?
+    private var handler: (() -> Void)?
+
+    /// Identifies our hotkey in the Carbon callback. Arbitrary, but must be stable.
+    private static let signature: OSType = 0x4D42_5452 // 'MBTR'
+    private let identifier: UInt32 = 1
+
+    deinit {
+        unregister()
+    }
+
+    /// Registers `shortcut` system-wide, replacing any previously registered one.
+    ///
+    /// Throws if Carbon rejects the combination, leaving nothing registered — callers
+    /// that want to keep the old shortcut on failure must re-register it themselves.
+    func register(_ shortcut: GlobalShortcut, handler: @escaping () -> Void) throws {
+        unregister()
+        self.handler = handler
+
+        installEventHandlerIfNeeded()
+
+        let hotKeyID = EventHotKeyID(signature: Self.signature, id: identifier)
+        var ref: EventHotKeyRef?
+        let status = RegisterEventHotKey(UInt32(shortcut.keyCode),
+                                         shortcut.carbonModifiers,
+                                         hotKeyID,
+                                         GetEventDispatcherTarget(),
+                                         0,
+                                         &ref)
+
+        guard status == noErr, let ref else {
+            self.handler = nil
+            throw RegistrationError.unavailable(status)
+        }
+        hotKeyRef = ref
+    }
+
+    /// Removes the hotkey. Safe to call when nothing is registered.
+    func unregister() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+            self.hotKeyRef = nil
+        }
+        handler = nil
+    }
+
+    /// Installs the Carbon event handler once and leaves it installed. Registering and
+    /// unregistering hotkeys doesn't require tearing it down, and reinstalling per
+    /// registration would risk leaking handlers.
+    private func installEventHandlerIfNeeded() {
+        guard eventHandler == nil else { return }
+
+        var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                 eventKind: UInt32(kEventHotKeyPressed))
+
+        // Carbon is a C API with no notion of self, so pass an unretained pointer back to
+        // this instance. Unretained is safe because deinit removes the handler, so the
+        // callback cannot outlive the object it points at.
+        let context = Unmanaged.passUnretained(self).toOpaque()
+
+        InstallEventHandler(GetEventDispatcherTarget(), { _, event, userData in
+            guard let event, let userData else { return OSStatus(eventNotHandledErr) }
+
+            var firedID = EventHotKeyID()
+            let status = GetEventParameter(event,
+                                           EventParamName(kEventParamDirectObject),
+                                           EventParamType(typeEventHotKeyID),
+                                           nil,
+                                           MemoryLayout<EventHotKeyID>.size,
+                                           nil,
+                                           &firedID)
+            guard status == noErr else { return status }
+
+            let center = Unmanaged<HotKeyCenter>.fromOpaque(userData).takeUnretainedValue()
+            guard firedID.signature == HotKeyCenter.signature,
+                  firedID.id == center.identifier else {
+                return OSStatus(eventNotHandledErr)
+            }
+
+            // Carbon calls back on the main thread, but the handler touches AppKit, so be
+            // explicit rather than relying on that.
+            DispatchQueue.main.async { center.handler?() }
+            return noErr
+        }, 1, &spec, context, &eventHandler)
+    }
+}

--- a/Translate Menu/Preferences.swift
+++ b/Translate Menu/Preferences.swift
@@ -1,0 +1,45 @@
+/*
+* Copyright (c) 2015 Adrián Moreno Peña
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+import Foundation
+
+/// The app's stored preferences.
+///
+/// Deliberately a thin, injectable wrapper rather than reads scattered through the code:
+/// the defaults it touches decide whether the app asks for Accessibility at all, so it is
+/// worth being able to test the exact answer it gives.
+enum Preferences {
+    private static let translateSelectionKey = "translateSelection"
+
+    /// Whether pressing the global shortcut should translate the current selection.
+    ///
+    /// **Defaults to false, and that matters.** Reading the selection needs Accessibility
+    /// permission, and nobody should be prompted for that because they installed a
+    /// translate window. `UserDefaults.bool(forKey:)` already returns false for a missing
+    /// or non-boolean value, which is the behaviour we want: anything unreadable means off.
+    static func translateSelection(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: translateSelectionKey)
+    }
+
+    static func setTranslateSelection(_ enabled: Bool, in defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: translateSelectionKey)
+    }
+}

--- a/Translate Menu/SelectionReader.swift
+++ b/Translate Menu/SelectionReader.swift
@@ -1,0 +1,109 @@
+/*
+* Copyright (c) 2015 Adrián Moreno Peña
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+import ApplicationServices
+import Cocoa
+
+/// Reads the text currently selected in whatever app is frontmost.
+///
+/// The only part of the app that touches Accessibility. It reads via the AX API and never
+/// touches the pasteboard — the alternative (synthesising cmd+C) would overwrite whatever
+/// the user had copied, and a spike confirmed AX covers native *and* Chromium apps, so
+/// there is nothing to gain from it.
+///
+/// Requires Accessibility permission, which is why the feature is opt-in. Without the
+/// grant every AX call fails quietly rather than erroring, so this type reports "no
+/// selection" and the popover simply opens empty — the app's behaviour before the feature.
+enum SelectionReader {
+
+    /// Beyond this the text is not a "selection" any more, and it has to survive being
+    /// placed in the Google Translate URL. A cmd+A on a long page would otherwise build an
+    /// absurd URL for text nobody meant to translate.
+    static let maximumLength = 2000
+
+    /// Whether macOS currently allows this app to read other apps' UI.
+    static var isPermitted: Bool { AXIsProcessTrusted() }
+
+    /// Asks macOS to prompt for Accessibility. The prompt is shown at most once per app;
+    /// afterwards the user must go to System Settings themselves, which is why callers
+    /// should also offer `openSettingsPane()`.
+    static func requestPermission() {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
+    }
+
+    static func openSettingsPane() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// The frontmost app's selected text, or nil if there isn't any worth translating.
+    ///
+    /// Returns nil rather than throwing on every failure path: a missing permission, an
+    /// element with no selection, and a non-text element are all "open empty" as far as
+    /// the caller is concerned, and none of them is worth interrupting the user over.
+    static func readSelection() -> String? {
+        guard isPermitted else { return nil }
+
+        guard let front = NSWorkspace.shared.frontmostApplication,
+              front.processIdentifier != ProcessInfo.processInfo.processIdentifier
+        else {
+            // If we are frontmost there is no other app's selection to read, and reading
+            // our own popover would translate the translation.
+            return nil
+        }
+
+        let app = AXUIElementCreateApplication(front.processIdentifier)
+
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXFocusedUIElementAttribute as CFString, &focused) == .success,
+              let element = focused
+        else { return nil }
+
+        var selection: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element as! AXUIElement,
+                                            kAXSelectedTextAttribute as CFString,
+                                            &selection) == .success,
+              let text = selection as? String
+        else { return nil }
+
+        return clean(text)
+    }
+
+    /// Tidies a raw AX selection into something worth putting in a translate URL.
+    ///
+    /// Split out from the AX plumbing above so it can be tested without a live session:
+    /// this is where the fiddly cases live, and the AX call around it cannot be unit tested.
+    static func clean(_ raw: String) -> String? {
+        // Chromium substitutes U+FFFC (object replacement) for inline images, so a page
+        // selection arrives peppered with them.
+        let withoutObjects = raw.replacingOccurrences(of: "\u{FFFC}", with: " ")
+
+        // Collapse the newlines and runs of spaces that come with any real-world selection.
+        let collapsed = withoutObjects
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        guard !collapsed.isEmpty else { return nil }
+        return String(collapsed.prefix(maximumLength))
+    }
+}

--- a/Translate Menu/SettingsWindowController.swift
+++ b/Translate Menu/SettingsWindowController.swift
@@ -41,6 +41,7 @@ final class SettingsWindowController: NSWindowController {
     private let permissionButton = NSButton(title: "Open System Settings", target: nil, action: nil)
 
     init(shortcut: GlobalShortcut?,
+         initialError: String? = nil,
          applyShortcut: @escaping (GlobalShortcut) -> String?,
          clearShortcut: @escaping () -> Void) {
         self.applyShortcut = applyShortcut
@@ -59,7 +60,10 @@ final class SettingsWindowController: NSWindowController {
 
         recorder.shortcut = shortcut
         buildLayout()
-        refreshStatus(message: nil)
+        // Surfaces a shortcut that was saved but failed to register at launch — e.g.
+        // another app has since claimed the combination. Without this the window would
+        // show the old shortcut as if it were live, with nothing registered behind it.
+        refreshStatus(message: initialError, isError: initialError != nil)
         refreshSelectionSection()
     }
 

--- a/Translate Menu/SettingsWindowController.swift
+++ b/Translate Menu/SettingsWindowController.swift
@@ -36,6 +36,9 @@ final class SettingsWindowController: NSWindowController {
 
     private let recorder = ShortcutRecorderView()
     private let statusLabel = NSTextField(labelWithString: "")
+    private let selectionCheckbox = NSButton(checkboxWithTitle: "Translate selected text", target: nil, action: nil)
+    private let permissionLabel = NSTextField(labelWithString: "")
+    private let permissionButton = NSButton(title: "Open System Settings", target: nil, action: nil)
 
     init(shortcut: GlobalShortcut?,
          applyShortcut: @escaping (GlobalShortcut) -> String?,
@@ -43,7 +46,7 @@ final class SettingsWindowController: NSWindowController {
         self.applyShortcut = applyShortcut
         self.clearShortcut = clearShortcut
 
-        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 420, height: 150),
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 420, height: 250),
                               styleMask: [.titled, .closable],
                               backing: .buffered,
                               defer: false)
@@ -52,10 +55,12 @@ final class SettingsWindowController: NSWindowController {
         window.center()
 
         super.init(window: window)
+        window.delegate = self
 
         recorder.shortcut = shortcut
         buildLayout()
         refreshStatus(message: nil)
+        refreshSelectionSection()
     }
 
     @available(*, unavailable)
@@ -93,7 +98,34 @@ final class SettingsWindowController: NSWindowController {
         statusLabel.lineBreakMode = .byWordWrapping
         statusLabel.maximumNumberOfLines = 2
 
-        for view in [title, explanation, recorder, clearButton, statusLabel] {
+        selectionCheckbox.target = self
+        selectionCheckbox.action = #selector(toggleTranslateSelection)
+
+        let selectionExplanation = NSTextField(labelWithString: "Translate whatever is selected when you press the shortcut.")
+        selectionExplanation.font = .systemFont(ofSize: 11)
+        selectionExplanation.textColor = .secondaryLabelColor
+
+        permissionLabel.font = .systemFont(ofSize: 11)
+        permissionLabel.lineBreakMode = .byWordWrapping
+        permissionLabel.maximumNumberOfLines = 3
+
+        permissionButton.target = self
+        permissionButton.action = #selector(openAccessibilitySettings)
+        permissionButton.bezelStyle = .rounded
+        permissionButton.controlSize = .small
+
+        statusLabel.font = .systemFont(ofSize: 11)
+        statusLabel.textColor = .secondaryLabelColor
+        statusLabel.lineBreakMode = .byWordWrapping
+        statusLabel.maximumNumberOfLines = 2
+
+        let divider = NSBox()
+        divider.boxType = .separator
+
+        let views: [NSView] = [title, explanation, recorder, clearButton, statusLabel,
+                               divider, selectionCheckbox, selectionExplanation,
+                               permissionLabel, permissionButton]
+        for view in views {
             view.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview(view)
         }
@@ -115,8 +147,65 @@ final class SettingsWindowController: NSWindowController {
 
             statusLabel.leadingAnchor.constraint(equalTo: title.leadingAnchor),
             statusLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
-            statusLabel.topAnchor.constraint(equalTo: recorder.bottomAnchor, constant: 12),
+            statusLabel.topAnchor.constraint(equalTo: recorder.bottomAnchor, constant: 10),
+
+            divider.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            divider.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            divider.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 12),
+
+            selectionCheckbox.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            selectionCheckbox.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 12),
+
+            selectionExplanation.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            selectionExplanation.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            selectionExplanation.topAnchor.constraint(equalTo: selectionCheckbox.bottomAnchor, constant: 2),
+
+            permissionLabel.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            permissionLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            permissionLabel.topAnchor.constraint(equalTo: selectionExplanation.bottomAnchor, constant: 8),
+
+            permissionButton.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            permissionButton.topAnchor.constraint(equalTo: permissionLabel.bottomAnchor, constant: 6),
         ])
+    }
+
+    /// The checkbox stores the user's *intent*; whether it can actually work depends on a
+    /// permission macOS controls. Those are tracked separately on purpose — a ticked box
+    /// that silently does nothing is the failure this avoids.
+    @objc
+    private func toggleTranslateSelection() {
+        let wantsIt = selectionCheckbox.state == .on
+        Preferences.setTranslateSelection(wantsIt)
+
+        if wantsIt && !SelectionReader.isPermitted {
+            // Only prompt when the user asks for the feature — never on launch.
+            SelectionReader.requestPermission()
+        }
+        refreshSelectionSection()
+    }
+
+    @objc
+    private func openAccessibilitySettings() {
+        SelectionReader.openSettingsPane()
+    }
+
+    private func refreshSelectionSection() {
+        selectionCheckbox.state = Preferences.translateSelection() ? .on : .off
+
+        let wantsIt = Preferences.translateSelection()
+        let permitted = SelectionReader.isPermitted
+
+        // Only nag when the user has actually asked for the feature.
+        let needsPermission = wantsIt && !permitted
+        permissionLabel.isHidden = !needsPermission
+        permissionButton.isHidden = !needsPermission
+
+        if needsPermission {
+            permissionLabel.stringValue = "Reading the selection needs Accessibility permission. "
+                + "Allow “Translate Menu” in System Settings, then it will work. "
+                + "Until then the shortcut opens an empty window."
+            permissionLabel.textColor = .systemOrange
+        }
     }
 
     @objc
@@ -155,5 +244,14 @@ final class SettingsWindowController: NSWindowController {
         showWindow(nil)
         window?.makeKeyAndOrderFront(nil)
         window?.orderFrontRegardless()
+        refreshSelectionSection()
+    }
+}
+
+extension SettingsWindowController: NSWindowDelegate {
+    /// Granting Accessibility happens in System Settings, outside this app, so the user
+    /// comes back to a window whose warning is stale. Re-check whenever it regains focus.
+    func windowDidBecomeKey(_ notification: Notification) {
+        refreshSelectionSection()
     }
 }

--- a/Translate Menu/SettingsWindowController.swift
+++ b/Translate Menu/SettingsWindowController.swift
@@ -138,11 +138,22 @@ final class SettingsWindowController: NSWindowController {
         }
     }
 
-    /// Shows the window and brings it forward. A menu bar app isn't the active app, so it
-    /// has to activate explicitly or the window opens behind whatever the user was using.
+    /// Shows the window and brings it forward.
+    ///
+    /// Getting this in front is fiddlier than it looks. A menu bar app is not the active
+    /// app, so the window opens behind whatever the user was in unless we activate first —
+    /// and `activate(ignoringOtherApps:)` has had no effect since macOS 14, so relying on
+    /// it alone means the window opens invisibly behind the browser. Hence all three:
+    /// the modern activate on 14+, the old one below it, and orderFrontRegardless() to
+    /// force the window up even if activation is refused (which is what the popover does).
     func present() {
-        NSApp.activate(ignoringOtherApps: true)
+        if #available(macOS 14.0, *) {
+            NSApp.activate()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
         showWindow(nil)
         window?.makeKeyAndOrderFront(nil)
+        window?.orderFrontRegardless()
     }
 }

--- a/Translate Menu/SettingsWindowController.swift
+++ b/Translate Menu/SettingsWindowController.swift
@@ -1,0 +1,148 @@
+/*
+* Copyright (c) 2015 Adrián Moreno Peña
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+import Cocoa
+
+/// The Settings window. Built in code rather than a xib: it is one row, and the recorder
+/// is a custom view that a xib could not describe anyway.
+///
+/// Owns no behaviour of its own — it wires the recorder to persistence and to the caller's
+/// re-registration, and reports back whatever that returns.
+final class SettingsWindowController: NSWindowController {
+    /// Asked to apply a newly recorded shortcut. Returns an error message to display, or
+    /// nil on success. The controller doesn't know how registration works; it just shows
+    /// the outcome.
+    private let applyShortcut: (GlobalShortcut) -> String?
+    /// Asked to remove the shortcut entirely.
+    private let clearShortcut: () -> Void
+
+    private let recorder = ShortcutRecorderView()
+    private let statusLabel = NSTextField(labelWithString: "")
+
+    init(shortcut: GlobalShortcut?,
+         applyShortcut: @escaping (GlobalShortcut) -> String?,
+         clearShortcut: @escaping () -> Void) {
+        self.applyShortcut = applyShortcut
+        self.clearShortcut = clearShortcut
+
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 420, height: 150),
+                              styleMask: [.titled, .closable],
+                              backing: .buffered,
+                              defer: false)
+        window.title = "Settings"
+        window.isReleasedWhenClosed = false
+        window.center()
+
+        super.init(window: window)
+
+        recorder.shortcut = shortcut
+        buildLayout()
+        refreshStatus(message: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not used — this window is built in code")
+    }
+
+    private func buildLayout() {
+        guard let contentView = window?.contentView else { return }
+
+        let title = NSTextField(labelWithString: "Global shortcut")
+        title.font = .boldSystemFont(ofSize: 13)
+
+        let explanation = NSTextField(labelWithString: "Opens the translate window from any app.")
+        explanation.font = .systemFont(ofSize: 11)
+        explanation.textColor = .secondaryLabelColor
+
+        recorder.onRecord = { [weak self] shortcut in
+            guard let self else { return }
+            if let error = self.applyShortcut(shortcut) {
+                // Registration failed. Show the reason and drop the field back to whatever
+                // is actually registered, so the UI never claims a shortcut that isn't live.
+                self.refreshStatus(message: error, isError: true)
+                self.recorder.shortcut = GlobalShortcut.load()
+            } else {
+                self.refreshStatus(message: nil)
+            }
+        }
+
+        let clearButton = NSButton(title: "Clear", target: self, action: #selector(clear))
+        clearButton.bezelStyle = .rounded
+
+        statusLabel.font = .systemFont(ofSize: 11)
+        statusLabel.textColor = .secondaryLabelColor
+        statusLabel.lineBreakMode = .byWordWrapping
+        statusLabel.maximumNumberOfLines = 2
+
+        for view in [title, explanation, recorder, clearButton, statusLabel] {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(view)
+        }
+
+        NSLayoutConstraint.activate([
+            title.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            title.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
+
+            explanation.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            explanation.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+
+            recorder.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            recorder.topAnchor.constraint(equalTo: explanation.bottomAnchor, constant: 12),
+            recorder.widthAnchor.constraint(equalToConstant: 180),
+            recorder.heightAnchor.constraint(equalToConstant: 28),
+
+            clearButton.leadingAnchor.constraint(equalTo: recorder.trailingAnchor, constant: 8),
+            clearButton.centerYAnchor.constraint(equalTo: recorder.centerYAnchor),
+
+            statusLabel.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            statusLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            statusLabel.topAnchor.constraint(equalTo: recorder.bottomAnchor, constant: 12),
+        ])
+    }
+
+    @objc
+    private func clear() {
+        clearShortcut()
+        recorder.shortcut = nil
+        refreshStatus(message: nil)
+    }
+
+    private func refreshStatus(message: String?, isError: Bool = false) {
+        if let message {
+            statusLabel.stringValue = message
+            statusLabel.textColor = isError ? .systemRed : .secondaryLabelColor
+        } else if recorder.shortcut == nil {
+            statusLabel.stringValue = "No shortcut set."
+            statusLabel.textColor = .secondaryLabelColor
+        } else {
+            statusLabel.stringValue = ""
+        }
+    }
+
+    /// Shows the window and brings it forward. A menu bar app isn't the active app, so it
+    /// has to activate explicitly or the window opens behind whatever the user was using.
+    func present() {
+        NSApp.activate(ignoringOtherApps: true)
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+    }
+}

--- a/Translate Menu/ShortcutRecorderView.swift
+++ b/Translate Menu/ShortcutRecorderView.swift
@@ -1,0 +1,148 @@
+/*
+* Copyright (c) 2015 Adrián Moreno Peña
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+import Carbon.HIToolbox
+import Cocoa
+
+/// A field that records one keyboard shortcut.
+///
+/// Click it, press a combination, and it reports a `GlobalShortcut`. It only turns
+/// keystrokes into values — it doesn't save them or register anything, so it can be
+/// reasoned about without involving Carbon or UserDefaults.
+final class ShortcutRecorderView: NSView {
+    /// Called with a valid shortcut. Not called for rejected combinations.
+    var onRecord: ((GlobalShortcut) -> Void)?
+
+    /// The shortcut to display when not recording.
+    var shortcut: GlobalShortcut? {
+        didSet { needsDisplay = true }
+    }
+
+    private var isRecording = false {
+        didSet { needsDisplay = true }
+    }
+
+    /// Set when the user pressed something without ⌘/⌥/⌃, so the view can explain itself
+    /// rather than appearing to ignore the keystroke.
+    private var showsModifierHint = false {
+        didSet { needsDisplay = true }
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+    override var isFlipped: Bool { true }
+
+    override func becomeFirstResponder() -> Bool {
+        isRecording = true
+        return true
+    }
+
+    override func resignFirstResponder() -> Bool {
+        isRecording = false
+        showsModifierHint = false
+        return true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        guard isRecording else {
+            super.keyDown(with: event)
+            return
+        }
+
+        // Escape abandons recording and leaves the existing shortcut alone. Recording it
+        // would be a poor trade: ⎋ is how you back out of things everywhere else in macOS.
+        if event.keyCode == UInt16(kVK_Escape) {
+            window?.makeFirstResponder(nil)
+            return
+        }
+
+        guard let recorded = GlobalShortcut(keyCode: event.keyCode, modifiers: event.modifierFlags) else {
+            // Rejected: no ⌘/⌥/⌃. Stay in recording mode so the user can simply try again.
+            showsModifierHint = true
+            NSSound.beep()
+            return
+        }
+
+        showsModifierHint = false
+        shortcut = recorded
+        onRecord?(recorded)
+        window?.makeFirstResponder(nil)
+    }
+
+    /// Modifier-only presses shouldn't be recorded, but the view should look alive while
+    /// the user holds ⌘ waiting to pick a key.
+    override func flagsChanged(with event: NSEvent) {
+        guard isRecording else { return }
+        needsDisplay = true
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        let rounded = NSBezierPath(roundedRect: bounds.insetBy(dx: 1, dy: 1), xRadius: 6, yRadius: 6)
+
+        NSColor.controlBackgroundColor.setFill()
+        rounded.fill()
+
+        (isRecording ? NSColor.controlAccentColor : NSColor.separatorColor).setStroke()
+        rounded.lineWidth = isRecording ? 2 : 1
+        rounded.stroke()
+
+        let style = NSMutableParagraphStyle()
+        style.alignment = .center
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 13),
+            .foregroundColor: textColour,
+            .paragraphStyle: style,
+        ]
+
+        let text = displayText as NSString
+        let size = text.size(withAttributes: attributes)
+        let origin = NSRect(x: 0,
+                            y: (bounds.height - size.height) / 2,
+                            width: bounds.width,
+                            height: size.height)
+        text.draw(in: origin, withAttributes: attributes)
+    }
+
+    private var textColour: NSColor {
+        if showsModifierHint { return .systemRed }
+        if isRecording { return .secondaryLabelColor }
+        return shortcut == nil ? .secondaryLabelColor : .labelColor
+    }
+
+    private var displayText: String {
+        if showsModifierHint { return "Add ⌘, ⌥ or ⌃" }
+        if isRecording {
+            // Echo the modifiers already held, so the field responds while the user decides.
+            let held = NSEvent.modifierFlags.intersection([.command, .option, .control, .shift])
+            if !held.isEmpty, let partial = GlobalShortcut(keyCode: 0, modifiers: held) {
+                return String(partial.displayString.dropLast(GlobalShortcut.keyName(for: 0).count))
+            }
+            return "Press a shortcut…"
+        }
+        return shortcut?.displayString ?? "Click to record"
+    }
+}

--- a/Translate Menu/ShortcutRecorderView.swift
+++ b/Translate Menu/ShortcutRecorderView.swift
@@ -46,17 +46,26 @@ final class ShortcutRecorderView: NSView {
         didSet { needsDisplay = true }
     }
 
+    /// The modifiers currently held during a recording session, captured from
+    /// `flagsChanged` rather than read live from `NSEvent.modifierFlags` at draw time.
+    /// Keeping our own copy makes what's on screen a function of the events this view
+    /// actually received, not of whatever the keyboard happens to be doing when AppKit
+    /// gets around to calling `draw(_:)`.
+    private var recordingModifiers: NSEvent.ModifierFlags = []
+
     override var acceptsFirstResponder: Bool { true }
     override var isFlipped: Bool { true }
 
     override func becomeFirstResponder() -> Bool {
         isRecording = true
+        recordingModifiers = []
         return true
     }
 
     override func resignFirstResponder() -> Bool {
         isRecording = false
         showsModifierHint = false
+        recordingModifiers = []
         return true
     }
 
@@ -94,6 +103,10 @@ final class ShortcutRecorderView: NSView {
     /// the user holds ⌘ waiting to pick a key.
     override func flagsChanged(with event: NSEvent) {
         guard isRecording else { return }
+        recordingModifiers = event.modifierFlags
+        // A fresh modifier press means the user is trying again — don't leave a stale
+        // "Add ⌘, ⌥ or ⌃" error on screen once they've started doing exactly that.
+        showsModifierHint = false
         needsDisplay = true
     }
 
@@ -137,7 +150,7 @@ final class ShortcutRecorderView: NSView {
         if showsModifierHint { return "Add ⌘, ⌥ or ⌃" }
         if isRecording {
             // Echo the modifiers already held, so the field responds while the user decides.
-            let held = NSEvent.modifierFlags.intersection([.command, .option, .control, .shift])
+            let held = recordingModifiers.intersection([.command, .option, .control, .shift])
             if !held.isEmpty, let partial = GlobalShortcut(keyCode: 0, modifiers: held) {
                 return String(partial.displayString.dropLast(GlobalShortcut.keyName(for: 0).count))
             }

--- a/Translate MenuTests/GlobalShortcutTests.swift
+++ b/Translate MenuTests/GlobalShortcutTests.swift
@@ -1,0 +1,177 @@
+//
+//  GlobalShortcutTests.swift
+//  Translate MenuTests
+//
+//  Unit tests for the global shortcut value type.
+//
+//  GlobalShortcut is deliberately pure — no Carbon, no UI, no global state — so the rules
+//  that matter can be tested in-process with no Accessibility permission and no window
+//  server. That is the whole reason the validation lives here rather than in the recorder
+//  view: a test can reach it, and a future caller cannot skip it.
+//
+
+import Carbon.HIToolbox
+import XCTest
+@testable import Translate_Menu
+
+final class GlobalShortcutTests: XCTestCase {
+
+    /// kVK_ANSI_T — an arbitrary printable key, used wherever the key itself is irrelevant.
+    private let keyT = UInt16(kVK_ANSI_T)
+
+    // MARK: - Validation
+    //
+    // The important behaviour in this type. A global hotkey with no ⌘/⌥/⌃ fires on every
+    // press of that key in every app: record "T" and typing "t" in Mail opens the
+    // translator over the message. These tests are the guard against that shipping.
+
+    func test_init_rejectsBareKey() {
+        XCTAssertNil(GlobalShortcut(keyCode: keyT, modifiers: []),
+                     "A key with no modifiers would fire on every press of that key, everywhere")
+    }
+
+    func test_init_rejectsShiftOnly() {
+        XCTAssertNil(GlobalShortcut(keyCode: keyT, modifiers: [.shift]),
+                     "⇧T is just a capital T — shift alone must not qualify")
+    }
+
+    func test_init_rejectsFunctionAndCapsLockOnly() {
+        XCTAssertNil(GlobalShortcut(keyCode: keyT, modifiers: [.capsLock]))
+        XCTAssertNil(GlobalShortcut(keyCode: keyT, modifiers: [.function]))
+        XCTAssertNil(GlobalShortcut(keyCode: keyT, modifiers: [.capsLock, .shift]))
+    }
+
+    func test_init_acceptsEachQualifyingModifier() {
+        XCTAssertNotNil(GlobalShortcut(keyCode: keyT, modifiers: [.command]))
+        XCTAssertNotNil(GlobalShortcut(keyCode: keyT, modifiers: [.option]))
+        XCTAssertNotNil(GlobalShortcut(keyCode: keyT, modifiers: [.control]))
+    }
+
+    func test_init_acceptsShiftWhenCombinedWithAQualifier() {
+        XCTAssertNotNil(GlobalShortcut(keyCode: keyT, modifiers: [.shift, .command]),
+                        "⇧⌘T is fine — shift just cannot be the only modifier")
+    }
+
+    // MARK: - Normalisation
+
+    func test_init_ignoresCapsLock() {
+        // Caps Lock is a state, not an intent. ⌘T pressed with Caps Lock on is still ⌘T,
+        // and must compare equal — the same class of bug that broke cmd+C/V/A in #13.
+        let withCaps = GlobalShortcut(keyCode: keyT, modifiers: [.command, .capsLock])
+        let without = GlobalShortcut(keyCode: keyT, modifiers: [.command])
+        XCTAssertEqual(withCaps, without)
+    }
+
+    func test_init_discardsIrrelevantFlags() {
+        // NSEvent hands over flags we don't care about (numeric pad, function, device
+        // -dependent bits). Storing them would make two identical shortcuts compare unequal.
+        let noisy = GlobalShortcut(keyCode: keyT, modifiers: [.command, .numericPad, .function])
+        let clean = GlobalShortcut(keyCode: keyT, modifiers: [.command])
+        XCTAssertEqual(noisy, clean)
+    }
+
+    // MARK: - Display
+
+    func test_displayString_usesStandardModifierOrder() {
+        // macOS orders modifiers ⌃⌥⇧⌘ everywhere; matching it means the field reads the
+        // same as the shortcut printed in any other app's menu.
+        let all = GlobalShortcut(keyCode: keyT, modifiers: [.command, .shift, .option, .control])
+        XCTAssertEqual(all?.displayString, "⌃⌥⇧⌘T")
+    }
+
+    func test_displayString_singleModifier() {
+        XCTAssertEqual(GlobalShortcut(keyCode: keyT, modifiers: [.command])?.displayString, "⌘T")
+        XCTAssertEqual(GlobalShortcut(keyCode: keyT, modifiers: [.option])?.displayString, "⌥T")
+    }
+
+    func test_displayString_namesNonPrintableKeys() {
+        // Keys with no character of their own get a glyph rather than "Key 49".
+        XCTAssertEqual(GlobalShortcut(keyCode: UInt16(kVK_Space), modifiers: [.command])?.displayString, "⌘Space")
+        XCTAssertEqual(GlobalShortcut(keyCode: UInt16(kVK_LeftArrow), modifiers: [.command])?.displayString, "⌘←")
+        XCTAssertEqual(GlobalShortcut(keyCode: UInt16(kVK_Return), modifiers: [.command])?.displayString, "⌘↩")
+    }
+
+    // MARK: - Carbon translation
+    //
+    // Carbon uses its own modifier constants, unrelated to NSEvent's. Getting this mapping
+    // wrong registers a shortcut the user never asked for, which is hard to spot by eye.
+
+    func test_carbonModifiers_mapsEachModifier() {
+        XCTAssertEqual(GlobalShortcut(keyCode: keyT, modifiers: [.command])?.carbonModifiers, UInt32(cmdKey))
+        XCTAssertEqual(GlobalShortcut(keyCode: keyT, modifiers: [.option])?.carbonModifiers, UInt32(optionKey))
+        XCTAssertEqual(GlobalShortcut(keyCode: keyT, modifiers: [.control])?.carbonModifiers, UInt32(controlKey))
+    }
+
+    func test_carbonModifiers_combinesModifiers() {
+        let shortcut = GlobalShortcut(keyCode: keyT, modifiers: [.command, .option])
+        XCTAssertEqual(shortcut?.carbonModifiers, UInt32(cmdKey) | UInt32(optionKey))
+        // Guards the exact value verified against a live registration of ⌥⌘T.
+        XCTAssertEqual(shortcut?.carbonModifiers, 2304)
+    }
+
+    func test_carbonModifiers_excludesCapsLock() {
+        // Carbon has no caps lock hotkey modifier; leaking it in would corrupt the mask.
+        let shortcut = GlobalShortcut(keyCode: keyT, modifiers: [.command, .capsLock])
+        XCTAssertEqual(shortcut?.carbonModifiers, UInt32(cmdKey))
+    }
+
+    // MARK: - Persistence
+
+    /// A throwaway defaults domain per test, so these never touch the real app's settings.
+    private func makeDefaults(_ name: String = #function) -> UserDefaults {
+        let suite = "GlobalShortcutTests.\(name)"
+        UserDefaults().removePersistentDomain(forName: suite)
+        return UserDefaults(suiteName: suite)!
+    }
+
+    func test_load_returnsNilWhenNothingSaved() {
+        XCTAssertNil(GlobalShortcut.load(from: makeDefaults()),
+                     "No shortcut set is the default state — nothing may be registered")
+    }
+
+    func test_saveThenLoad_roundTrips() {
+        let defaults = makeDefaults()
+        let original = GlobalShortcut(keyCode: keyT, modifiers: [.command, .option])!
+
+        original.save(to: defaults)
+
+        XCTAssertEqual(GlobalShortcut.load(from: defaults), original)
+    }
+
+    func test_clear_removesTheShortcut() {
+        let defaults = makeDefaults()
+        GlobalShortcut(keyCode: keyT, modifiers: [.command])!.save(to: defaults)
+        XCTAssertNotNil(GlobalShortcut.load(from: defaults))
+
+        GlobalShortcut.clear(in: defaults)
+
+        XCTAssertNil(GlobalShortcut.load(from: defaults))
+    }
+
+    func test_load_rejectsStoredValueThatFailsValidation() {
+        // Defaults are editable by hand, and an older build could have written something
+        // today's rules reject. Loading it would register a bare-key hotkey — so a stored
+        // value has to clear the same bar as a freshly recorded one.
+        let defaults = makeDefaults()
+        defaults.set(Int(keyT), forKey: "globalShortcutKeyCode")
+        defaults.set(0, forKey: "globalShortcutModifiers") // no modifiers
+
+        XCTAssertNil(GlobalShortcut.load(from: defaults))
+    }
+
+    func test_load_returnsNilWhenOnlyOneHalfIsPresent() {
+        let defaults = makeDefaults()
+        defaults.set(Int(keyT), forKey: "globalShortcutKeyCode")
+        // modifiers deliberately absent — a partial write must not read as "no modifiers".
+
+        XCTAssertNil(GlobalShortcut.load(from: defaults))
+    }
+
+    func test_load_rejectsOutOfRangeKeyCode() {
+        let defaults = makeDefaults()
+        defaults.set(Int(UInt32.max), forKey: "globalShortcutKeyCode") // too big for UInt16
+        defaults.set(Int(NSEvent.ModifierFlags.command.rawValue), forKey: "globalShortcutModifiers")
+
+        XCTAssertNil(GlobalShortcut.load(from: defaults))
+    }
+}

--- a/Translate MenuTests/SelectionTests.swift
+++ b/Translate MenuTests/SelectionTests.swift
@@ -1,0 +1,103 @@
+//
+//  SelectionTests.swift
+//  Translate MenuTests
+//
+//  Tests for the two pure pieces of the translate-selection feature: the preference that
+//  decides whether Accessibility is ever requested, and the cleaning applied to a raw AX
+//  selection before it goes into a URL.
+//
+//  SelectionReader.readSelection() itself is not here: it needs a live AX session, a
+//  frontmost app and a granted permission. It is kept deliberately thin for that reason —
+//  everything worth testing sits either side of the AX call.
+//
+
+import XCTest
+@testable import Translate_Menu
+
+final class PreferencesTests: XCTestCase {
+
+    private func makeDefaults(_ name: String = #function) -> UserDefaults {
+        let suite = "PreferencesTests.\(name)"
+        UserDefaults().removePersistentDomain(forName: suite)
+        return UserDefaults(suiteName: suite)!
+    }
+
+    func test_translateSelection_defaultsToOff() {
+        // The load-bearing default. If this were on, every user would be prompted for
+        // Accessibility on first launch for a feature they never asked for.
+        XCTAssertFalse(Preferences.translateSelection(in: makeDefaults()))
+    }
+
+    func test_translateSelection_roundTrips() {
+        let defaults = makeDefaults()
+
+        Preferences.setTranslateSelection(true, in: defaults)
+        XCTAssertTrue(Preferences.translateSelection(in: defaults))
+
+        Preferences.setTranslateSelection(false, in: defaults)
+        XCTAssertFalse(Preferences.translateSelection(in: defaults))
+    }
+
+    func test_translateSelection_readsAsOffWhenValueIsNotABool() {
+        // Defaults are hand-editable. Anything unreadable must mean off, never on.
+        let defaults = makeDefaults()
+        defaults.set("yes please", forKey: "translateSelection")
+
+        XCTAssertFalse(Preferences.translateSelection(in: defaults))
+    }
+}
+
+final class SelectionCleaningTests: XCTestCase {
+
+    func test_clean_passesOrdinaryTextThrough() {
+        XCTAssertEqual(SelectionReader.clean("Hola mundo"), "Hola mundo")
+    }
+
+    func test_clean_stripsObjectReplacementCharacters() {
+        // Chromium substitutes U+FFFC for inline images, so a page selection arrives
+        // peppered with them — verified against a real Vivaldi selection during the spike.
+        XCTAssertEqual(SelectionReader.clean("\u{FFFC}Hola\u{FFFC} mundo\u{FFFC}"), "Hola mundo")
+    }
+
+    func test_clean_collapsesWhitespaceAndNewlines() {
+        XCTAssertEqual(SelectionReader.clean("Hola\n\n   mundo\t\tcruel"), "Hola mundo cruel")
+    }
+
+    func test_clean_trimsSurroundingWhitespace() {
+        XCTAssertEqual(SelectionReader.clean("   Hola mundo   "), "Hola mundo")
+    }
+
+    func test_clean_returnsNilForEmptyInput() {
+        XCTAssertNil(SelectionReader.clean(""))
+    }
+
+    func test_clean_returnsNilForWhitespaceOnly() {
+        XCTAssertNil(SelectionReader.clean("   \n\t  "))
+    }
+
+    func test_clean_returnsNilWhenOnlyObjectReplacements() {
+        // A selection of nothing but images has no text to translate.
+        XCTAssertNil(SelectionReader.clean("\u{FFFC}\u{FFFC}\u{FFFC}"))
+    }
+
+    func test_clean_capsLongSelections() {
+        // A cmd+A on a long page would otherwise build an absurd translate URL.
+        let long = String(repeating: "a", count: SelectionReader.maximumLength * 2)
+
+        let cleaned = SelectionReader.clean(long)
+
+        XCTAssertEqual(cleaned?.count, SelectionReader.maximumLength)
+    }
+
+    func test_clean_doesNotCapTextAtTheLimit() {
+        let exact = String(repeating: "b", count: SelectionReader.maximumLength)
+
+        XCTAssertEqual(SelectionReader.clean(exact)?.count, SelectionReader.maximumLength)
+    }
+
+    func test_clean_preservesNonLatinText() {
+        // The app's whole purpose. Capping by character must not mangle multi-byte text.
+        XCTAssertEqual(SelectionReader.clean("你好世界"), "你好世界")
+        XCTAssertEqual(SelectionReader.clean("  Привет   мир "), "Привет мир")
+    }
+}


### PR DESCRIPTION
Closes #3, requested by @feppos0 in #2 — in 2019.

Press a shortcut from any app to open the translate popover, and choose the shortcut yourself in a new Settings window.

Design spec: [`Docs/superpowers/specs/2026-07-16-global-shortcut-design.md`](Docs/superpowers/specs/2026-07-16-global-shortcut-design.md).

## No default shortcut

Nothing is registered until the user picks a combination. Global hotkeys are scarce shared real estate — claiming one at install could silently break a combo the user already relies on, without them ever consenting. The cost is discoverability, which is why "Settings…" sits directly under the version in the right-click menu.

## Why Carbon, and not the obvious choice

`NSEvent.addGlobalMonitorForEvents` would have been the natural pick — `EventMonitor.swift` already uses the local variant. It's wrong here for two reasons:

1. It requires Accessibility permission — a scary prompt plus a System Settings trip, for a convenience feature.
2. **It cannot consume the event.** The keystroke would still reach the frontmost app, so the shortcut would open the translator *and* type into whatever you were doing.

The second is disqualifying. Carbon's `RegisterEventHotKey` works inside the sandbox with no permission prompt and consumes the keystroke. It looks archaic because Apple never shipped a replacement.

I also considered `sindresorhus/KeyboardShortcuts` — genuinely good, and less code — but it would be this project's first dependency for something that's ~150 lines to do directly.

## The bare-key hazard

This is the one way the feature can go badly wrong, so it's worth stating plainly: **a global hotkey with no modifier fires on every press of that key, in every app.** Record `T` and typing "t" in Mail opens the translator over your message. Shift alone doesn't help — `⇧T` is just a capital T.

So `GlobalShortcut` refuses to exist without at least one of `⌘`/`⌥`/`⌃`. That validation lives in the value type rather than the recorder view, so a future caller can't bypass it, and so it's testable without a UI.

## Structure

Four files, each with one job:

| File | Responsibility |
|---|---|
| `GlobalShortcut.swift` | Value type: validation, display string, defaults round-trip, NSEvent→Carbon modifier translation. Pure. |
| `HotKeyCenter.swift` | The only file that knows Carbon exists. |
| `ShortcutRecorderView.swift` | Turns keystrokes into values. No Carbon, no persistence. |
| `SettingsWindowController.swift` | Assembles the window, wires the recorder. |

Registration failure is surfaced rather than swallowed: if another app owns the combination, Settings says so and the *previous* shortcut stays live — defaults never describe a hotkey that isn't actually registered.

## Verified end to end

Registered `⌥⌘T`, pressed it **from Finder**, and the popover opened with Google Translate loaded. Pressed again — it closed. Confirmed the modifier translation is right (`carbonMods=2304` = `cmdKey` 256 + `optionKey` 2048).

## Still worth checking by hand

- [ ] Recording via the Settings UI (I verified registration by seeding defaults; the recorder view itself is unexercised)
- [ ] Clear button removes the shortcut and it stays cleared across relaunch
- [ ] Recording a combo another app owns shows the error and keeps the old one

## Note on merge order

Also adds a `statusMenu` item in `applicationDidFinishLaunching`, as does #18 (Start at Login). Whichever merges second needs a small conflict resolution there — limited to menu-item insertion order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)