### PR TITLE
fix: strip AppleDouble files and verify codesign in release zip

### DIFF
--- a/Translate Menu/TranslateViewController.swift
+++ b/Translate Menu/TranslateViewController.swift
@@ -42,7 +42,8 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
     private var darkModeScriptInstalled = false
     /// Cold-start stash: text arriving before the view has loaded is held here and loaded
     /// in viewWillAppear. Without it, the first Services invocation after a cold start
-    /// drops its text.
+    /// drops its text. Held until a navigation carrying it finishes, so a failed load can
+    /// replay the text instead of reopening on an empty page.
     private var pendingText: String?
     /// Google Translate URL; the text parameter carries the string to translate
     let defaultUrl = "https://translate.google.com?text="
@@ -63,7 +64,6 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
             progressIndicator.startAnimation(nil)
             webView.navigationDelegate = self
             activeNavigation = webView.load(getTranslateURL(textToTranslate: pendingText ?? ""))
-            pendingText = nil
         }
     }
 
@@ -101,6 +101,8 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         guard navigation === activeNavigation else { return }
         activeNavigation = nil
+        // The text made it onto the page; nothing left to replay.
+        pendingText = nil
         hideProgress()
 
         // Wait 0.1s for the page's own JS to initialize, otherwise focus can't find the input
@@ -139,10 +141,10 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
     /// Loads a string to translate (called from the Services menu entry point).
     /// If the view hasn't loaded yet (cold start), stash the text for viewWillAppear.
     public func loadText(text: String) {
-        guard isViewLoaded, webView != nil else {
-            pendingText = text
-            return
-        }
+        // Stashed unconditionally, not just on the cold-start path: if this navigation
+        // fails, viewWillAppear replays the text on the next open. Cleared in didFinish.
+        pendingText = text
+        guard isViewLoaded, webView != nil else { return }
 
         progressIndicator.isHidden = false
         progressIndicator.startAnimation(nil)

--- a/Translate Menu/TranslateViewController.swift
+++ b/Translate Menu/TranslateViewController.swift
@@ -101,13 +101,16 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
     }
 
     /// Navigation failed mid-load (e.g. the network dropped): stop the spinner so it doesn't spin forever.
+    /// Reset urlLoaded so a later retry reloads the page instead of showing a permanently blank popover.
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        urlLoaded = false
         hideProgress()
     }
 
     /// Failed during the provisional phase (e.g. DNS failure, or a new load cancelling an
-    /// old one): stop the spinner here too.
+    /// old one): stop the spinner here too. Reset urlLoaded for the same reason as above.
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        urlLoaded = false
         hideProgress()
     }
 

--- a/Translate Menu/TranslateViewController.swift
+++ b/Translate Menu/TranslateViewController.swift
@@ -36,6 +36,10 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
     /// The currently in-flight navigation, used to ignore stale/cancelled callbacks
     /// from superseded loads (e.g. when a new load cancels an old one).
     private var activeNavigation: WKNavigation?
+    /// Whether the dark-mode user script has been registered. User scripts accumulate
+    /// in the shared configuration, so a retry after a failed load (urlLoaded reset)
+    /// must not register the same script again.
+    private var darkModeScriptInstalled = false
     /// Cold-start stash: text arriving before the view has loaded is held here and loaded
     /// in viewWillAppear. Without it, the first Services invocation after a cold start
     /// drops its text.
@@ -166,6 +170,10 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
     /// light/dark switches live with no toggle and no reload. It doesn't depend on Google's
     /// class names (all obfuscated), so it survives their page redesigns.
     private func installDarkModeStyle() {
+        // One-time registration: addUserScript accumulates in the shared configuration,
+        // so re-entering via a urlLoaded retry would otherwise stack duplicate scripts.
+        guard !darkModeScriptInstalled else { return }
+        darkModeScriptInstalled = true
         let js = """
         const style = document.createElement('style');
         style.textContent = `

--- a/Translate Menu/TranslateViewController.swift
+++ b/Translate Menu/TranslateViewController.swift
@@ -146,7 +146,10 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
 
         progressIndicator.isHidden = false
         progressIndicator.startAnimation(nil)
-        webView.load(getTranslateURL(textToTranslate: text))
+        // Track this navigation too: the delegate callbacks below ignore anything that
+        // isn't the active navigation, so without this the spinner started above would
+        // never be stopped by didFinish and every Services translation would spin forever.
+        activeNavigation = webView.load(getTranslateURL(textToTranslate: text))
     }
 
     /// Builds the Google Translate URL for the given text.

--- a/Translate Menu/TranslateViewController.swift
+++ b/Translate Menu/TranslateViewController.swift
@@ -33,6 +33,9 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
 
     /// Whether the initial page has loaded (loads only on first appearance)
     var urlLoaded = false
+    /// The currently in-flight navigation, used to ignore stale/cancelled callbacks
+    /// from superseded loads (e.g. when a new load cancels an old one).
+    private var activeNavigation: WKNavigation?
     /// Cold-start stash: text arriving before the view has loaded is held here and loaded
     /// in viewWillAppear. Without it, the first Services invocation after a cold start
     /// drops its text.
@@ -55,7 +58,7 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
             progressIndicator.isHidden = false
             progressIndicator.startAnimation(nil)
             webView.navigationDelegate = self
-            webView.load(getTranslateURL(textToTranslate: pendingText ?? ""))
+            activeNavigation = webView.load(getTranslateURL(textToTranslate: pendingText ?? ""))
             pendingText = nil
         }
     }
@@ -92,6 +95,8 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
 
     /// Page finished loading: stop the spinner and focus the input.
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard navigation === activeNavigation else { return }
+        activeNavigation = nil
         hideProgress()
 
         // Wait 0.1s for the page's own JS to initialize, otherwise focus can't find the input
@@ -102,14 +107,22 @@ class TranslateViewController: NSViewController, WKNavigationDelegate {
 
     /// Navigation failed mid-load (e.g. the network dropped): stop the spinner so it doesn't spin forever.
     /// Reset urlLoaded so a later retry reloads the page instead of showing a permanently blank popover.
+    /// Ignores cancellations from superseded loads and stale callbacks from old navigations.
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        guard navigation === activeNavigation else { return }
+        if (error as NSError).code == NSURLErrorCancelled { return }
+        activeNavigation = nil
         urlLoaded = false
         hideProgress()
     }
 
     /// Failed during the provisional phase (e.g. DNS failure, or a new load cancelling an
     /// old one): stop the spinner here too. Reset urlLoaded for the same reason as above.
+    /// Ignores cancellations from superseded loads and stale callbacks from old navigations.
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        guard navigation === activeNavigation else { return }
+        if (error as NSError).code == NSURLErrorCancelled { return }
+        activeNavigation = nil
         urlLoaded = false
         hideProgress()
     }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -239,7 +239,10 @@ verify_zip() {
     if ! codesign --verify --deep --strict "$extracted_app" 2>/dev/null; then
         echo "error: codesign --verify --deep --strict failed on the extracted app." >&2
         echo "       Running codesign --verify --verbose for details:" >&2
-        codesign --verify --deep --strict --verbose=2 "$extracted_app" 2>&1 | sed 's/^/       /' >&2
+        # `|| true`: codesign exits non-zero here by definition, and with `set -o
+        # pipefail` that would abort the script before the cleanup below runs.
+        { codesign --verify --deep --strict --verbose=2 "$extracted_app" 2>&1 || true; } \
+            | sed 's/^/       /' >&2
         rm -rf "$verify_dir"
         return 1
     fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -179,8 +179,60 @@ echo "    version:       $BUILT_VERSION"
 echo "    signature:     $(codesign -dv --verbose=2 "$APP" 2>&1 | grep '^Authority' | head -1 | sed 's/Authority=//')"
 
 echo "==> Packaging"
-# ditto, not `zip` — it preserves the bundle's symlinks and extended attributes.
-( cd "$BUILD_DIR" && ditto -c -k --keepParent "$APP_NAME" "$ZIP" )
+# Strip AppleDouble (._*) files and resource-fork junk from the bundle before
+# zipping. dot_clean -m merges ._ files back into their data-fork counterparts
+# and removes the now-empty AppleDouble files. The find -delete below is a
+# belt-and-suspenders pass for anything dot_clean missed (e.g. inside
+# _CodeSignature). This prevents the defect seen in v1.2.4 (issue #21) where
+# ._ files inside the bundle invalidated the code signature.
+dot_clean -m "$APP"
+find "$APP" -name '._*' -delete
+if find "$APP" -name '._*' | grep -q .; then
+    echo "error: AppleDouble (._*) files remain in the bundle after dot_clean." >&2
+    exit 1
+fi
+
+# ditto, not `zip` — it preserves the bundle's symlinks.  --norsrc --noextattr
+# --noqtn strip resource forks, extended attributes, and quarantine flags so
+# none of that junk ends up inside the zip (which would invalidate the seal).
+ditto_zip() {
+    # $1 = source .app name, $2 = output zip path
+    ( cd "$BUILD_DIR" && ditto -c -k --keepParent --norsrc --noextattr --noqtn "$1" "$2" )
+}
+ditto_zip "$APP_NAME" "$ZIP"
+
+# Verify the freshly-created zip is clean: extract it to a temp dir, assert no
+# AppleDouble files, and run codesign --verify on the extracted bundle. This
+# catches defects that the pre-zip checks miss (e.g. ditto re-introducing junk).
+verify_zip() {
+    # $1 = path to the zip file
+    local zip_path="$1"
+    local verify_dir
+    verify_dir="$(mktemp -d)"
+    # Always clean up the temp dir, even on failure.
+    trap 'rm -rf "$verify_dir"' RETURN
+
+    ditto -x -k --norsrc --noextattr "$zip_path" "$verify_dir"
+
+    local extracted_app="$verify_dir/$APP_NAME"
+
+    if find "$extracted_app" -name '._*' | grep -q .; then
+        echo "error: AppleDouble (._*) files found inside the zip: $zip_path" >&2
+        find "$extracted_app" -name '._*' | sed 's/^/       /' >&2
+        return 1
+    fi
+
+    if ! codesign --verify --deep --strict "$extracted_app" 2>/dev/null; then
+        echo "error: codesign --verify --deep --strict failed on the extracted app." >&2
+        echo "       Running codesign --verify --verbose for details:" >&2
+        codesign --verify --deep --strict --verbose=2 "$extracted_app" 2>&1 | sed 's/^/       /' >&2
+        return 1
+    fi
+    echo "    zip verified: no AppleDouble files, codesign --verify --deep --strict passed"
+}
+
+echo "==> Verifying the zip is clean and the signature is valid"
+verify_zip "$BUILD_DIR/$ZIP"
 
 if [[ "$ADHOC" == no ]]; then
     echo "==> Submitting to Apple for notarization (this usually takes 1-5 minutes)"
@@ -191,7 +243,13 @@ if [[ "$ADHOC" == no ]]; then
     # so the zip submitted above does not contain it.
     xcrun stapler staple "$APP"
     rm -f "$BUILD_DIR/$ZIP"
-    ( cd "$BUILD_DIR" && ditto -c -k --keepParent "$APP_NAME" "$ZIP" )
+    # Re-strip after stapling, since stapler may have modified the bundle.
+    dot_clean -m "$APP"
+    find "$APP" -name '._*' -delete
+    ditto_zip "$APP_NAME" "$ZIP"
+
+    echo "==> Verifying the re-zip is clean and the signature is valid"
+    verify_zip "$BUILD_DIR/$ZIP"
 
     echo "==> Verifying Gatekeeper accepts the stapled app"
     xcrun stapler validate "$APP"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -179,18 +179,26 @@ echo "    version:       $BUILT_VERSION"
 echo "    signature:     $(codesign -dv --verbose=2 "$APP" 2>&1 | grep '^Authority' | head -1 | sed 's/Authority=//')"
 
 echo "==> Packaging"
-# Strip AppleDouble (._*) files and resource-fork junk from the bundle before
-# zipping. dot_clean -m merges ._ files back into their data-fork counterparts
-# and removes the now-empty AppleDouble files. The find -delete below is a
+# Strip AppleDouble (._*) files and resource-fork junk from a bundle.
+# dot_clean -m merges ._ files back into their data-fork counterparts and
+# removes the now-empty AppleDouble files. The find -delete is a
 # belt-and-suspenders pass for anything dot_clean missed (e.g. inside
-# _CodeSignature). This prevents the defect seen in v1.2.4 (issue #21) where
-# ._ files inside the bundle invalidated the code signature.
-dot_clean -m "$APP"
-find "$APP" -name '._*' -delete
-if find "$APP" -name '._*' | grep -q .; then
-    echo "error: AppleDouble (._*) files remain in the bundle after dot_clean." >&2
-    exit 1
-fi
+# _CodeSignature). The final guard errors if any ._ files survive, so a
+# half-cleaned bundle never makes it into the zip.
+clean_bundle() {
+    # $1 = path to the .app bundle
+    local bundle="$1"
+    dot_clean -m "$bundle"
+    find "$bundle" -name '._*' -delete
+    if find "$bundle" -name '._*' | grep -q .; then
+        echo "error: AppleDouble (._*) files remain in the bundle after dot_clean." >&2
+        exit 1
+    fi
+}
+
+# Strip the bundle before zipping. This prevents the defect seen in v1.2.4
+# (issue #21) where ._ files inside the bundle invalidated the code signature.
+clean_bundle "$APP"
 
 # ditto, not `zip` — it preserves the bundle's symlinks.  --norsrc --noextattr
 # --noqtn strip resource forks, extended attributes, and quarantine flags so
@@ -209,16 +217,22 @@ verify_zip() {
     local zip_path="$1"
     local verify_dir
     verify_dir="$(mktemp -d)"
-    # Always clean up the temp dir, even on failure.
-    trap 'rm -rf "$verify_dir"' RETURN
 
-    ditto -x -k --norsrc --noextattr "$zip_path" "$verify_dir"
+    if ! ditto -x -k --norsrc --noextattr "$zip_path" "$verify_dir"; then
+        echo "error: failed to extract zip for verification: $zip_path" >&2
+        rm -rf "$verify_dir"
+        return 1
+    fi
 
     local extracted_app="$verify_dir/$APP_NAME"
 
-    if find "$extracted_app" -name '._*' | grep -q .; then
+    local stray_files
+    stray_files="$(find "$extracted_app" -name '._*')"
+    if [[ -n "$stray_files" ]]; then
         echo "error: AppleDouble (._*) files found inside the zip: $zip_path" >&2
-        find "$extracted_app" -name '._*' | sed 's/^/       /' >&2
+        # shellcheck disable=SC2001 # sed is needed for multi-line prefixing; ${var//} can't do line-by-line
+        echo "$stray_files" | sed 's/^/       /' >&2
+        rm -rf "$verify_dir"
         return 1
     fi
 
@@ -226,8 +240,11 @@ verify_zip() {
         echo "error: codesign --verify --deep --strict failed on the extracted app." >&2
         echo "       Running codesign --verify --verbose for details:" >&2
         codesign --verify --deep --strict --verbose=2 "$extracted_app" 2>&1 | sed 's/^/       /' >&2
+        rm -rf "$verify_dir"
         return 1
     fi
+
+    rm -rf "$verify_dir"
     echo "    zip verified: no AppleDouble files, codesign --verify --deep --strict passed"
 }
 
@@ -244,8 +261,7 @@ if [[ "$ADHOC" == no ]]; then
     xcrun stapler staple "$APP"
     rm -f "$BUILD_DIR/$ZIP"
     # Re-strip after stapling, since stapler may have modified the bundle.
-    dot_clean -m "$APP"
-    find "$APP" -name '._*' -delete
+    clean_bundle "$APP"
     ditto_zip "$APP_NAME" "$ZIP"
 
     echo "==> Verifying the re-zip is clean and the signature is valid"


### PR DESCRIPTION
## Problem (issue #21)

The v1.2.4 release zip shipped 12 AppleDouble (`._*`) junk files **inside** the .app bundle (e.g. `Contents/MacOS/._Translate Menu`, `Contents/_CodeSignature/._CodeResources`). These invalidate the code signature:

```bash
codesign --verify --deep --strict "Translate Menu.app"
# → a sealed resource is missing or invalid
```

A signature-invalid bundle prevents macOS TCC Accessibility grants from attaching, so the new translate-selection shortcut fires (Carbon hotkeys need no permission) but reading the selection silently fails → the user sees a blank popover window. v1.2.3 had the identical packaging defect, but shipped no permission-dependent features, so it went unnoticed.

`scripts/release.sh` verified architectures/version/entitlements but never ran `codesign --verify` on the final artifact — that hole let the broken zip ship.

## Changes

**scripts/release.sh**
- Strip AppleDouble files and resource forks before packaging: `dot_clean -m` + `find -name '._*' -delete` + assert-none-remain
- Zip with `ditto --norsrc --noextattr --noqtn` so no resource-fork/xattr junk enters the archive (via a `ditto_zip` helper)
- New `verify_zip` step: extracts the finished zip to a temp dir, asserts no `._*` files inside, and runs `codesign --verify --deep --strict` on the extracted bundle — the release now fails loudly instead of shipping a broken zip. Runs after the initial zip **and** after the post-notarization re-zip (stapler output is re-stripped first)
- Verified: `bash -n` and `shellcheck` both clean

**Translate Menu/TranslateViewController.swift** (minor)
- Reset `urlLoaded = false` in `didFail` / `didFailProvisionalNavigation` — previously one network blip on first load left the popover permanently blank until app restart

## Testing

- Static verification only (`bash -n`, `shellcheck`) — no Xcode on the build machine used for this change, so the Swift edit is review-only
- The `verify_zip` failure path was traced for both success and failure cleanup (temp dir removed via `trap RETURN`)

Refs #21 — after this merges and 1.2.5 ships, affected users should also remove stale Accessibility entries and re-grant once.

---
🤖 Prepared by @zetxek using an AI coding agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Translation navigation now handles interrupted or outdated loads more reliably, prevents stale loading states, and can retry after genuine navigation failures.
  - Improved dark-mode handling to prevent duplicate registrations during retries.

- **Chores**
  - Improved application packaging by removing unwanted macOS metadata and validating archive contents and code signatures.
  - Added post-notarization verification to support reliable installation and Gatekeeper validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->