### PR TITLE
Bump version to 1.2.5

### DIFF
--- a/Translate Menu.xcodeproj/project.pbxproj
+++ b/Translate Menu.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "info.adrianmoreno.Translate-Menu";
 				PRODUCT_NAME = "Translate Menu";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -462,7 +462,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "info.adrianmoreno.Translate-Menu";
 				PRODUCT_NAME = "Translate Menu";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Bumps `MARKETING_VERSION` to 1.2.5 in both build configurations, so `scripts/release.sh 1.2.5` will run.

New since v1.2.4: the release-packaging fix from #22 — AppleDouble (`._*`) files were shipping inside the .app bundle and invalidating the code signature (#21), plus the popover/spinner fixes that came out of reviewing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)