### PR TITLE
Never let a Services invocation do nothing (1.2.7)

### DIFF
--- a/Translate Menu.xcodeproj/project.pbxproj
+++ b/Translate Menu.xcodeproj/project.pbxproj
@@ -14,7 +14,9 @@
 		0AC0CE1F1C81AEF700305ACF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AC0CE1E1C81AEF700305ACF /* Images.xcassets */; };
 		0AC0CE271C81B02B00305ACF /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AC0CE261C81B02B00305ACF /* WebKit.framework */; };
 		0C660F7BC3B445480E693D12 /* HotKeyCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */; };
+		12CEC867717EE8FE210103BD /* PasteboardTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB7583BACC41F98EB7255D5E /* PasteboardTextTests.swift */; };
 		15BA783BB0F7C25D1A25CC5F /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */; };
+		3EB1C924D43A3B9E0C04FC43 /* PasteboardText.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CA5D2CD9E26800DE52D9F2 /* PasteboardText.swift */; };
 		5077E61A2CEA791500EFBF1B /* TranslateWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5077E6192CEA791500EFBF1B /* TranslateWebView.swift */; };
 		6F814C345FFE89CECEE73347 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 182AC6B3CA0EEFCD8EB7D9E3 /* Cocoa.framework */; };
 		90CBC726DE69E6FCEF510C9E /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169A7A70292E08096E5B0C30 /* ShortcutRecorderView.swift */; };
@@ -52,6 +54,8 @@
 		DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HotKeyCenter.swift; path = "Translate Menu/HotKeyCenter.swift"; sourceTree = SOURCE_ROOT; };
 		E7DE0D382344A22D00A9CBAD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "Translate Menu/Info.plist"; sourceTree = SOURCE_ROOT; };
 		E7DE0D3A2344A24C00A9CBAD /* MainMenu.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = MainMenu.xib; path = "Translate Menu/MainMenu.xib"; sourceTree = SOURCE_ROOT; };
+		EB7583BACC41F98EB7255D5E /* PasteboardTextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PasteboardTextTests.swift; path = "Translate MenuTests/PasteboardTextTests.swift"; sourceTree = SOURCE_ROOT; };
+		F9CA5D2CD9E26800DE52D9F2 /* PasteboardText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PasteboardText.swift; path = "Translate Menu/PasteboardText.swift"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +82,7 @@
 			isa = PBXGroup;
 			children = (
 				054AE720EF7A4AABBCC1B727 /* GlobalShortcutTests.swift */,
+				EB7583BACC41F98EB7255D5E /* PasteboardTextTests.swift */,
 			);
 			name = "Translate MenuTests";
 			sourceTree = "<group>";
@@ -126,6 +131,7 @@
 				DA311E6C91A796D25B41C5AE /* HotKeyCenter.swift */,
 				169A7A70292E08096E5B0C30 /* ShortcutRecorderView.swift */,
 				3455DA34E0783A9FE5E372F8 /* SettingsWindowController.swift */,
+				F9CA5D2CD9E26800DE52D9F2 /* PasteboardText.swift */,
 			);
 			name = "Translate Menu";
 			path = Quotes;
@@ -246,6 +252,7 @@
 				0C660F7BC3B445480E693D12 /* HotKeyCenter.swift in Sources */,
 				90CBC726DE69E6FCEF510C9E /* ShortcutRecorderView.swift in Sources */,
 				15BA783BB0F7C25D1A25CC5F /* SettingsWindowController.swift in Sources */,
+				3EB1C924D43A3B9E0C04FC43 /* PasteboardText.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,6 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FC32F2806B452F8026449579 /* GlobalShortcutTests.swift in Sources */,
+				12CEC867717EE8FE210103BD /* PasteboardTextTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -420,7 +428,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.2.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "info.adrianmoreno.Translate-Menu";
 				PRODUCT_NAME = "Translate Menu";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -450,7 +458,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.2.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "info.adrianmoreno.Translate-Menu";
 				PRODUCT_NAME = "Translate Menu";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Translate Menu/AppDelegate.swift
+++ b/Translate Menu/AppDelegate.swift
@@ -249,13 +249,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// macOS Services menu entry point: text selected in another app → "Translate in MenuTranslate" → here.
     /// The system passes the selected text in via the pasteboard.
+    ///
+    /// The window opens either way. This used to `return` when the pasteboard held nothing
+    /// it could read, which from the outside looked exactly like the app launching and
+    /// doing nothing — the user asked for the translator, so they get the translator, and
+    /// the unreadable case is logged rather than swallowed.
     @objc
     func translateService(_ pasteboard: NSPasteboard,
                           userData: String,
                           error: AutoreleasingUnsafeMutablePointer<NSString?>) {
-        guard let text = pasteboard.string(forType: .string) else { return }
+        if let text = PasteboardText.read(from: pasteboard) {
+            translateViewController.loadText(text: text)
+        } else {
+            NSLog("AppDelegate: Services pasteboard carried no readable text. Types: "
+                  + PasteboardText.typeNames(of: pasteboard).joined(separator: ", "))
+        }
 
-        translateViewController.loadText(text: text)
         showPopover(sender: nil)
     }
 

--- a/Translate Menu/AppDelegate.swift
+++ b/Translate Menu/AppDelegate.swift
@@ -263,6 +263,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             NSLog("AppDelegate: Services pasteboard carried no readable text. Types: "
                   + PasteboardText.typeNames(of: pasteboard).joined(separator: ", "))
+            // Load empty rather than leaving the previous translation on screen. Answering
+            // "translate this selection" with an unrelated older translation reads as the
+            // app having ignored the request, and it would also let text stashed by an
+            // earlier failed load replay here, long after the user moved on.
+            translateViewController.loadText(text: "")
         }
 
         showPopover(sender: nil)

--- a/Translate Menu/Info.plist
+++ b/Translate Menu/Info.plist
@@ -53,9 +53,13 @@
 				<key>NSServiceCategory</key>
 				<string>public.item</string>
 			</dict>
+			<!-- RTF as well as plain text: apps that only offer a rich-text flavour of the
+			     selection would otherwise not show the service at all. PasteboardText
+			     flattens whatever arrives back to a plain string. -->
 			<key>NSSendTypes</key>
 			<array>
 				<string>NSStringPboardType</string>
+				<string>NSRTFPboardType</string>
 			</array>
 		</dict>
 	</array>

--- a/Translate Menu/PasteboardText.swift
+++ b/Translate Menu/PasteboardText.swift
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2015 Adrián Moreno Peña
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+import Cocoa
+
+/// Pulls translatable text out of the pasteboard macOS hands to the Services entry.
+///
+/// `.string` alone covers more than it looks like it does — AppKit coerces rich text, so
+/// even an RTF-only pasteboard answers it (pinned down in PasteboardTextTests). The
+/// fallback below is for what it does *not* coerce, and the point of the type is that a
+/// pasteboard it cannot read is reported rather than silently treated as "no selection".
+/// Split out from AppDelegate so the decoding can be tested against a real pasteboard.
+enum PasteboardText {
+
+    /// The selection as plain text, or nil if the pasteboard carries nothing usable.
+    ///
+    /// Whitespace-only content counts as nothing: translating it would just open Google
+    /// Translate on a blank query, which is what "no selection" already does.
+    static func read(from pasteboard: NSPasteboard) -> String? {
+        if let plain = pasteboard.string(forType: .string), !isBlank(plain) {
+            return plain
+        }
+
+        // One call covers RTF, RTFD and HTML: NSAttributedString declares all of them as
+        // readable types, so there is no need to hand-decode each flavour.
+        if let rich = pasteboard.readObjects(forClasses: [NSAttributedString.self]) as? [NSAttributedString] {
+            for candidate in rich where !isBlank(candidate.string) {
+                return candidate.string
+            }
+        }
+
+        return nil
+    }
+
+    /// The pasteboard's type identifiers, for logging a failed read. Callers use this to
+    /// make "it opened empty" reportable instead of a dead end.
+    static func typeNames(of pasteboard: NSPasteboard) -> [String] {
+        pasteboard.types?.map(\.rawValue) ?? []
+    }
+
+    private static func isBlank(_ text: String) -> Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/Translate MenuTests/PasteboardTextTests.swift
+++ b/Translate MenuTests/PasteboardTextTests.swift
@@ -1,0 +1,115 @@
+/*
+* Copyright (c) 2015 Adrián Moreno Peña
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+import XCTest
+@testable import Translate_Menu
+
+/// Runs against real `NSPasteboard` instances rather than a stub: the whole point of the
+/// type is how AppKit's own pasteboard behaves with each flavour, which a fake would only
+/// re-state as an assumption.
+final class PasteboardTextTests: XCTestCase {
+
+    /// A private, uniquely named pasteboard per test, so these never touch the user's
+    /// clipboard and cannot interfere with each other.
+    private func makePasteboard() -> NSPasteboard {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("PasteboardTextTests-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        return pasteboard
+    }
+
+    private func rtfData(_ string: String) throws -> Data {
+        let attributed = NSAttributedString(string: string)
+        return try XCTUnwrap(attributed.rtf(from: NSRange(location: 0, length: attributed.length),
+                                            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]))
+    }
+
+    func test_read_returnsPlainString() {
+        let pasteboard = makePasteboard()
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString("Hola mundo", forType: .string)
+
+        XCTAssertEqual(PasteboardText.read(from: pasteboard), "Hola mundo")
+    }
+
+    /// Pins down something surprising that this test suite established: asking a
+    /// rich-text-only pasteboard for `.string` **succeeds**, because AppKit coerces it.
+    /// So RTF-only selections were never the reason the service came up empty — worth
+    /// recording, or the next person will "fix" that non-problem again.
+    func test_read_readsARichTextOnlyPasteboard() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.declareTypes([.rtf], owner: nil)
+        pasteboard.setData(try rtfData("El perro corre"), forType: .rtf)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "El perro corre",
+                       "AppKit coerces rich text when asked for .string")
+        XCTAssertEqual(PasteboardText.read(from: pasteboard), "El perro corre")
+    }
+
+    func test_read_prefersPlainStringOverRichText() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.declareTypes([.string, .rtf], owner: nil)
+        pasteboard.setString("plain", forType: .string)
+        pasteboard.setData(try rtfData("rich"), forType: .rtf)
+
+        XCTAssertEqual(PasteboardText.read(from: pasteboard), "plain")
+    }
+
+    func test_read_returnsNilForEmptyPasteboard() {
+        XCTAssertNil(PasteboardText.read(from: makePasteboard()))
+    }
+
+    func test_read_returnsNilForWhitespaceOnlySelection() {
+        let pasteboard = makePasteboard()
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString("   \n\t ", forType: .string)
+
+        XCTAssertNil(PasteboardText.read(from: pasteboard))
+    }
+
+    func test_read_fallsBackWhenThePlainFlavourIsBlank() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.declareTypes([.string, .rtf], owner: nil)
+        pasteboard.setString("  ", forType: .string)
+        pasteboard.setData(try rtfData("con contenido"), forType: .rtf)
+
+        XCTAssertEqual(PasteboardText.read(from: pasteboard), "con contenido")
+    }
+
+    func test_read_preservesNonLatinText() {
+        let pasteboard = makePasteboard()
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString("日本語のテキスト", forType: .string)
+
+        XCTAssertEqual(PasteboardText.read(from: pasteboard), "日本語のテキスト")
+    }
+
+    func test_typeNames_listsWhatArrived() {
+        let pasteboard = makePasteboard()
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString("x", forType: .string)
+
+        XCTAssertTrue(PasteboardText.typeNames(of: pasteboard).contains(NSPasteboard.PasteboardType.string.rawValue))
+    }
+
+    func test_typeNames_isEmptyForEmptyPasteboard() {
+        XCTAssertTrue(PasteboardText.typeNames(of: makePasteboard()).isEmpty)
+    }
+}


### PR DESCRIPTION
Follow-up to #24, from a report that the Services entry "opens the app, but not the text I had selected".

## The defect

`translateService` began with:

```swift
guard let text = pasteboard.string(forType: .string) else { return }
```

If the pasteboard held nothing readable, the app returned silently. When the app was not already running, the Services invocation still launched it — so the user sees the app appear and then sit there, with no window, no error and nothing logged. That is the same silent-failure pattern #24 removed from the Accessibility path, left behind one function away.

## The fix

- The popover **always opens**. The user asked for the translator, so they get the translator, with or without text.
- The unreadable case is logged with the pasteboard's type identifiers, so a repeat report is diagnosable rather than a dead end.
- Reading moves into `PasteboardText`, with a `readObjects(forClasses: [NSAttributedString.self])` fallback.
- `NSSendTypes` now advertises RTF as well as plain text, so the service is offered by apps that only publish a rich-text flavour of the selection.

## One assumption corrected

Writing the tests disproved my own premise. Asking an **RTF-only** pasteboard for `.string` *succeeds* — AppKit coerces rich text. So rich-text selections were never why the service came up empty, and `test_read_readsARichTextOnlyPasteboard` now pins that behaviour down so the non-problem doesn't get "fixed" again. The behavioural change above is the actual fix.

## Testing

28 unit tests pass (9 new), run against real `NSPasteboard` instances on private, uniquely-named boards so they never touch the user's clipboard: plain text, RTF-only, both-present precedence, blank plain flavour falling through to rich text, whitespace-only, empty, non-Latin, and the type-name reporting used by the log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for translating text copied as plain text or rich text.
  * Prefers available plain text and falls back to rich-text content when needed.
  * The translation popover now opens even when no readable clipboard text is available.

* **Bug Fixes**
  * Improved handling of empty, whitespace-only, and non-Latin clipboard content.

* **Tests**
  * Added coverage for clipboard formats, fallback behavior, and text preservation.

* **Chores**
  * Updated the app version to 1.2.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->